### PR TITLE
[improvment] Init files import their subpackages.

### DIFF
--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/ConjurePythonGenerator.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/ConjurePythonGenerator.java
@@ -21,7 +21,9 @@ import com.google.common.collect.Sets;
 import com.palantir.conjure.python.client.ClientGenerator;
 import com.palantir.conjure.python.poet.PythonAll;
 import com.palantir.conjure.python.poet.PythonClass;
+import com.palantir.conjure.python.poet.PythonClassName;
 import com.palantir.conjure.python.poet.PythonFile;
+import com.palantir.conjure.python.poet.PythonImport;
 import com.palantir.conjure.python.poet.PythonLine;
 import com.palantir.conjure.python.poet.PythonMetaYaml;
 import com.palantir.conjure.python.poet.PythonSetup;
@@ -131,10 +133,14 @@ public final class ConjurePythonGenerator {
         String packageName = module.toString().replace('/', '.');
         PythonAll all = PythonAll.builder()
                 .packageName(packageName)
-                .addAllContents(submodules.stream().map(m -> m.toString()).sorted().collect(Collectors.toList()))
+                .addAllContents(submodules.stream().map(Path::toString).sorted().collect(Collectors.toList()))
                 .build();
+        Iterable<PythonImport> submoduleImports = submodules.stream().map(m ->
+                        PythonImport.of(PythonClassName.of(".", m.toString()))
+        ).collect(Collectors.toList());
         return PythonFile.builder()
                 .packageName(packageName)
+                .addAllImports(submoduleImports)
                 .addContents(all);
     }
 

--- a/conjure-python-core/src/test/resources/services/expected/package/__init__.py
+++ b/conjure-python-core/src/test/resources/services/expected/package/__init__.py
@@ -1,4 +1,7 @@
 # this is package package
+from . import another
+from . import product
+from . import product_datasets
 
 __all__ = [
     'another',

--- a/conjure-python-core/src/test/resources/types/expected/package/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package/__init__.py
@@ -1,4 +1,11 @@
 # this is package package
+from . import another
+from . import nested_deeply_nested_service
+from . import nested_service
+from . import nested_service2
+from . import product
+from . import product_datasets
+from . import with_imports
 
 __all__ = [
     'another',


### PR DESCRIPTION
This should allow for single-line imports of objects:
```python
from service_api import service_api
from service_api.service_api import Service
```
becomes
```python
from service_api.service_api import Service
```