### PR TITLE
[improvement] Use new picocli lib for CLI

### DIFF
--- a/conjure-python/build.gradle
+++ b/conjure-python/build.gradle
@@ -20,7 +20,7 @@ mainClassName = 'com.palantir.conjure.python.cli.ConjurePythonCli'
 
 dependencies {
     compile project(':conjure-python-core')
-    compile 'commons-cli:commons-cli'
+    compile 'info.picocli:picocli'
     runtime 'org.slf4j:slf4j-simple'
 
     testCompile 'junit:junit'

--- a/conjure-python/src/main/java/com/palantir/conjure/python/cli/CliConfiguration.java
+++ b/conjure-python/src/main/java/com/palantir/conjure/python/cli/CliConfiguration.java
@@ -20,23 +20,14 @@ import com.google.common.base.Preconditions;
 import com.palantir.tokens.auth.ImmutablesStyle;
 import java.io.File;
 import java.util.Optional;
-import org.apache.commons.cli.Option;
 import org.immutables.value.Value;
 
 @Value.Immutable
 @ImmutablesStyle
 public abstract class CliConfiguration {
-    static final String RAW_SOURCE = "rawSource";
-    static final String PACKAGE_NAME = "packageName";
-    static final String PACKAGE_VERSION = "packageVersion";
-    static final String PACKAGE_DESCRIPTION = "packageDescription";
-    static final String PACKAGE_URL = "packageUrl";
-    static final String PACKAGE_AUTHOR = "packageAuthor";
-    static final String WRITE_CONDA_RECIPE = "writeCondaRecipe";
+    abstract File input();
 
-    abstract File target();
-
-    abstract File outputDirectory();
+    abstract File output();
 
     abstract Optional<String> packageName();
 
@@ -63,43 +54,8 @@ public abstract class CliConfiguration {
 
     @Value.Check
     final void check() {
-        Preconditions.checkArgument(target().isFile(), "Target must exist and be a file");
-        Preconditions.checkArgument(outputDirectory().isDirectory(), "Output must exist and be a directory");
-    }
-
-    static CliConfiguration of(String target, String outputDirectory, Option[] options) {
-        Builder builder = new Builder()
-                .target(new File(target))
-                .outputDirectory(new File(outputDirectory));
-        for (Option option : options) {
-            switch (option.getLongOpt()) {
-                case PACKAGE_NAME:
-                    builder.packageName(option.getValue());
-                    break;
-                case PACKAGE_VERSION:
-                    String pythonicVersion = option.getValue().replace('-', '_');
-                    builder.packageVersion(pythonicVersion);
-                    break;
-                case PACKAGE_DESCRIPTION:
-                    builder.packageDescription(option.getValue());
-                    break;
-                case PACKAGE_URL:
-                    builder.packageUrl(option.getValue());
-                    break;
-                case PACKAGE_AUTHOR:
-                    builder.packageAuthor(option.getValue());
-                    break;
-                case WRITE_CONDA_RECIPE:
-                    builder.shouldWriteCondaRecipe(true);
-                    break;
-                case RAW_SOURCE:
-                    builder.generateRawSource(true);
-                    break;
-                default:
-                    break;
-            }
-        }
-        return builder.build();
+        Preconditions.checkArgument(input().isFile(), "Target must exist and be a file");
+        Preconditions.checkArgument(output().isDirectory(), "Output must exist and be a directory");
     }
 
     static Builder builder() {

--- a/versions.props
+++ b/versions.props
@@ -9,6 +9,7 @@ com.palantir.conjure.python:conjure-python-client = 1.1.2
 com.palantir.conjure.verification:* = 0.9.0
 com.palantir.conjure:* = 4.2.0
 commons-cli:commons-cli = 1.4
+info.picocli:picocli = 3.7.0
 junit:junit = 4.12
 org.apache.commons:commons-lang3 = 3.7
 org.assertj:* = 3.10.0


### PR DESCRIPTION
Similar to https://github.com/palantir/conjure-java/pull/91. Replace usage of commons cli with picocli


ex:
```
Usage: conjure-python generate [-hV] [--rawSource] [--writeCondaRecipe] [--packageDescription=<packageDescription>]
                               [--packageName=<packageName>] [--packageUrl=<packageUrl>]
                               [--packageVersion=<packageVersion>] <input> <output>
Generate Python bindings for a Conjure API
      <input>              Path to the input IR file
      <output>             Output directory for generated source
      --packageDescription=<packageDescription>
                           The description of the package to generate.
      --packageName=<packageName>
                           The name of the package to generate.
      --packageUrl=<packageUrl>
                           The url of the package to generate
      --packageVersion=<packageVersion>
                           The version of the package to generate.
      --rawSource          Only generate the plain source without any package metadata
      --writeCondaRecipe   Only generate the plain source without any package metadata
  -h, --help               Show this help message and exit.
  -V, --version            Print version information and exit.
```