### PR TITLE
[fix] sort types in endpoint defs, updated test files

### DIFF
--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java
@@ -99,6 +99,7 @@ public interface PythonEndpointDefinition extends Emittable {
             poetWriter.writeIndentedLine("# type: (%s) -> %s",
                     Joiner.on(", ").join(
                             paramsWithHeader.stream()
+                                    .sorted(new PythonEndpointParamComparator())
                                     .map(PythonEndpointParam::myPyType)
                                     .collect(Collectors.toList())),
                     myPyReturnType().orElse("None"));

--- a/conjure-python-core/src/test/resources/services/expected/package/another/__init__.py
+++ b/conjure-python-core/src/test/resources/services/expected/package/another/__init__.py
@@ -198,7 +198,7 @@ class TestService(Service):
         return
 
     def get_branches(self, auth_header, dataset_rid, message=None, page_size=None):
-        # type: (str, str, Optional[int], Optional[str]) -> List[str]
+        # type: (str, str, Optional[str], Optional[int]) -> List[str]
 
         _headers = {
             'Accept': 'application/json',

--- a/conjure-python-core/src/test/resources/types/expected/package/another/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package/another/__init__.py
@@ -198,7 +198,7 @@ class TestService(Service):
         return
 
     def get_branches(self, auth_header, dataset_rid, message=None, page_size=None):
-        # type: (str, str, Optional[int], Optional[str]) -> List[str]
+        # type: (str, str, Optional[str], Optional[int]) -> List[str]
 
         _headers = {
             'Accept': 'application/json',


### PR DESCRIPTION
fixed same way as `__init__` functions