### PR TITLE
[fix] Ensure aliases are defined before they are referenced

### DIFF
--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonFile.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonFile.java
@@ -67,16 +67,25 @@ public interface PythonFile extends Emittable {
 
     class PythonSnippetComparator implements Comparator<PythonSnippet> {
         @Override
-        public int compare(PythonSnippet pc1, PythonSnippet pc2) {
+        public int compare(PythonSnippet ps1, PythonSnippet ps2) {
             // PythonAliases need to occur last, since they potentially reference
             // objects defined in the current module
-            if (pc1 instanceof AliasSnippet && !(pc2 instanceof AliasSnippet)) {
+            if (ps1 instanceof AliasSnippet && !(ps2 instanceof AliasSnippet)) {
                 return 1;
-            } else if (!(pc1 instanceof AliasSnippet) && pc2 instanceof AliasSnippet) {
+            } else if (!(ps1 instanceof AliasSnippet) && ps2 instanceof AliasSnippet) {
                 return -1;
-            } else {
-                return Comparator.comparing(PythonSnippet::idForSorting).compare(pc1, pc2);
+            } else if ((ps1 instanceof AliasSnippet) && (ps2 instanceof AliasSnippet)) {
+                // Ensure that all aliases are defined before they are referenced by doing a simple topological sort
+                AliasSnippet as1 = (AliasSnippet) ps1;
+                AliasSnippet as2 = (AliasSnippet) ps2;
+                if (as1.className().contains(as2.aliasName())) {
+                    return -1;
+                }
+                if  (as2.className().contains(as1.aliasName())) {
+                    return 1;
+                }
             }
+            return Comparator.comparing(PythonSnippet::idForSorting).compare(ps1, ps2);
         }
     }
 }

--- a/conjure-python-core/src/test/resources/types/example-types.yml
+++ b/conjure-python-core/src/test/resources/types/example-types.yml
@@ -161,3 +161,6 @@ types:
           recursiveField: optional<RecursiveObjectAlias>
       RecursiveObjectAlias:
         alias: RecursiveObjectExample
+      # Importantly NestedAliasExample comes alphabetically before RecursiveObjectAlias
+      NestedAliasExample:
+        alias: RecursiveObjectAlias

--- a/conjure-python-core/src/test/resources/types/expected/package/product/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package/product/__init__.py
@@ -800,9 +800,9 @@ IntegerAliasExample = int
 
 MapAliasExample = DictType(str, object)
 
-NestedAliasExample = RecursiveObjectAlias
-
 RecursiveObjectAlias = RecursiveObjectExample
+
+NestedAliasExample = RecursiveObjectAlias
 
 ReferenceAliasExample = AnyExample
 

--- a/conjure-python-core/src/test/resources/types/expected/package/product/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package/product/__init__.py
@@ -800,6 +800,8 @@ IntegerAliasExample = int
 
 MapAliasExample = DictType(str, object)
 
+NestedAliasExample = RecursiveObjectAlias
+
 RecursiveObjectAlias = RecursiveObjectExample
 
 ReferenceAliasExample = AnyExample


### PR DESCRIPTION
## Before this PR
Alias types were generated at the bottom of the file alphabetically by the aliasName. This caused potential compilation failures as aliases could be referenced before being defined

## After this PR
Alias types are topologically sorted to ensure that they are always defined before being referenced
