### PR TITLE
[fix] Defensively import __builtin__ to protect against  conflict

### DIFF
--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/ConjurePythonGenerator.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/ConjurePythonGenerator.java
@@ -177,7 +177,8 @@ public final class ConjurePythonGenerator {
                 .putOptions("version", config.packageVersion().get())
                 .addInstallDependencies("requests", "typing")
                 .addInstallDependencies(String.format("conjure-python-client>=%s,<%s",
-                        config.minConjureClientVersion(), config.maxConjureClientVersion()));
+                        config.minConjureClientVersion(), config.maxConjureClientVersion()))
+                .addInstallDependencies("future");
         config.packageDescription().ifPresent(value -> builder.putOptions("description", value));
         config.packageUrl().ifPresent(value -> builder.putOptions("url", value));
         config.packageAuthor().ifPresent(value -> builder.putOptions("author", value));

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/BeanSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/BeanSnippet.java
@@ -17,6 +17,7 @@
 package com.palantir.conjure.python.poet;
 
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 import com.palantir.conjure.python.types.ImportTypeVisitor;
 import com.palantir.conjure.spec.Documentation;
 import java.util.List;
@@ -26,10 +27,12 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 public interface BeanSnippet extends PythonSnippet {
-    PythonImport CONJURE_IMPORT = PythonImport.builder()
-            .moduleSpecifier(ImportTypeVisitor.CONJURE_PYTHON_CLIENT)
-            .addNamedImports("ConjureBeanType", "ConjureFieldDefinition")
-            .build();
+    ImmutableList<PythonImport> DEFAULT_IMPORTS = ImmutableList.of(
+            PythonImport.builder()
+                    .moduleSpecifier(ImportTypeVisitor.CONJURE_PYTHON_CLIENT)
+                    .addNamedImports("ConjureBeanType", "ConjureFieldDefinition")
+                    .build(),
+            PythonImport.of("__builtin__"));
 
     @Override
     @Value.Default
@@ -52,7 +55,7 @@ public interface BeanSnippet extends PythonSnippet {
         poetWriter.writeLine();
 
         // record off the fields, for things like serialization (python... has no types)
-        poetWriter.writeIndentedLine("@classmethod");
+        poetWriter.writeIndentedLine("@__builtin__.classmethod");
         poetWriter.writeIndentedLine("def _fields(cls):");
         poetWriter.increaseIndent();
         poetWriter.writeIndentedLine("# type: () -> Dict[str, ConjureFieldDefinition]");
@@ -106,7 +109,7 @@ public interface BeanSnippet extends PythonSnippet {
         // each property
         fields().forEach(field -> {
             poetWriter.writeLine();
-            poetWriter.writeIndentedLine("@property");
+            poetWriter.writeIndentedLine("@__builtin__.property");
             poetWriter.writeIndentedLine(String.format("def %s(self):",
                     PythonIdentifierSanitizer.sanitize(field.attributeName())));
 

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/BeanSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/BeanSnippet.java
@@ -32,7 +32,7 @@ public interface BeanSnippet extends PythonSnippet {
                     .moduleSpecifier(ImportTypeVisitor.CONJURE_PYTHON_CLIENT)
                     .addNamedImports("ConjureBeanType", "ConjureFieldDefinition")
                     .build(),
-            PythonImport.of("builtin"));
+            PythonImport.of("builtins"));
 
     @Override
     @Value.Default
@@ -55,7 +55,7 @@ public interface BeanSnippet extends PythonSnippet {
         poetWriter.writeLine();
 
         // record off the fields, for things like serialization (python... has no types)
-        poetWriter.writeIndentedLine("@builtin.classmethod");
+        poetWriter.writeIndentedLine("@builtins.classmethod");
         poetWriter.writeIndentedLine("def _fields(cls):");
         poetWriter.increaseIndent();
         poetWriter.writeIndentedLine("# type: () -> Dict[str, ConjureFieldDefinition]");
@@ -109,7 +109,7 @@ public interface BeanSnippet extends PythonSnippet {
         // each property
         fields().forEach(field -> {
             poetWriter.writeLine();
-            poetWriter.writeIndentedLine("@builtin.property");
+            poetWriter.writeIndentedLine("@builtins.property");
             poetWriter.writeIndentedLine(String.format("def %s(self):",
                     PythonIdentifierSanitizer.sanitize(field.attributeName())));
 

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/BeanSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/BeanSnippet.java
@@ -32,7 +32,7 @@ public interface BeanSnippet extends PythonSnippet {
                     .moduleSpecifier(ImportTypeVisitor.CONJURE_PYTHON_CLIENT)
                     .addNamedImports("ConjureBeanType", "ConjureFieldDefinition")
                     .build(),
-            PythonImport.of("__builtin__"));
+            PythonImport.of("builtin"));
 
     @Override
     @Value.Default
@@ -55,7 +55,7 @@ public interface BeanSnippet extends PythonSnippet {
         poetWriter.writeLine();
 
         // record off the fields, for things like serialization (python... has no types)
-        poetWriter.writeIndentedLine("@__builtin__.classmethod");
+        poetWriter.writeIndentedLine("@builtin.classmethod");
         poetWriter.writeIndentedLine("def _fields(cls):");
         poetWriter.increaseIndent();
         poetWriter.writeIndentedLine("# type: () -> Dict[str, ConjureFieldDefinition]");
@@ -109,7 +109,7 @@ public interface BeanSnippet extends PythonSnippet {
         // each property
         fields().forEach(field -> {
             poetWriter.writeLine();
-            poetWriter.writeIndentedLine("@__builtin__.property");
+            poetWriter.writeIndentedLine("@builtin.property");
             poetWriter.writeIndentedLine(String.format("def %s(self):",
                     PythonIdentifierSanitizer.sanitize(field.attributeName())));
 

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonImport.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonImport.java
@@ -26,6 +26,10 @@ public interface PythonImport extends Emittable {
 
     Set<String> namedImports();
 
+    static PythonImport of(String moduleSpecifier) {
+        return builder().moduleSpecifier(moduleSpecifier).build();
+    }
+
     static PythonImport of(String moduleSpecifier, String namedImport) {
         return builder()
                 .moduleSpecifier(moduleSpecifier)
@@ -35,8 +39,13 @@ public interface PythonImport extends Emittable {
 
     @Override
     default void emit(PythonPoetWriter poetWriter) {
-        poetWriter.writeIndentedLine(String.format("from %s import %s",
-                moduleSpecifier(), namedImports().stream().sorted().collect(Collectors.joining(", "))));
+        // Namespace imports
+        if (namedImports().isEmpty()) {
+            poetWriter.writeIndentedLine(String.format("import %s", moduleSpecifier()));
+        } else {
+            poetWriter.writeIndentedLine(String.format("from %s import %s",
+                    moduleSpecifier(), namedImports().stream().sorted().collect(Collectors.joining(", "))));
+        }
     }
 
     class Builder extends ImmutablePythonImport.Builder {}

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
@@ -36,7 +36,7 @@ public interface UnionSnippet extends PythonSnippet {
                     .moduleSpecifier("abc")
                     .addNamedImports("ABCMeta", "abstractmethod")
                     .build(),
-            PythonImport.of("__builtin__"));
+            PythonImport.of("builtin"));
 
     @Override
     @Value.Default
@@ -64,7 +64,7 @@ public interface UnionSnippet extends PythonSnippet {
         poetWriter.writeLine();
 
         // record off the options
-        poetWriter.writeIndentedLine("@__builtin__.classmethod");
+        poetWriter.writeIndentedLine("@builtin.classmethod");
         poetWriter.writeIndentedLine("def _options(cls):");
         poetWriter.increaseIndent();
         poetWriter.writeIndentedLine("# type: () -> Dict[str, ConjureFieldDefinition]"); // maybe....?

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
@@ -36,7 +36,7 @@ public interface UnionSnippet extends PythonSnippet {
                     .moduleSpecifier("abc")
                     .addNamedImports("ABCMeta", "abstractmethod")
                     .build(),
-            PythonImport.of("builtin"));
+            PythonImport.of("builtins"));
 
     @Override
     @Value.Default
@@ -64,7 +64,7 @@ public interface UnionSnippet extends PythonSnippet {
         poetWriter.writeLine();
 
         // record off the options
-        poetWriter.writeIndentedLine("@builtin.classmethod");
+        poetWriter.writeIndentedLine("@builtins.classmethod");
         poetWriter.writeIndentedLine("def _options(cls):");
         poetWriter.increaseIndent();
         poetWriter.writeIndentedLine("# type: () -> Dict[str, ConjureFieldDefinition]"); // maybe....?

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
@@ -35,7 +35,8 @@ public interface UnionSnippet extends PythonSnippet {
             PythonImport.builder()
                     .moduleSpecifier("abc")
                     .addNamedImports("ABCMeta", "abstractmethod")
-                    .build());
+                    .build(),
+            PythonImport.of("__builtin__"));
 
     @Override
     @Value.Default
@@ -63,7 +64,7 @@ public interface UnionSnippet extends PythonSnippet {
         poetWriter.writeLine();
 
         // record off the options
-        poetWriter.writeIndentedLine("@classmethod");
+        poetWriter.writeIndentedLine("@__builtin__.classmethod");
         poetWriter.writeIndentedLine("def _options(cls):");
         poetWriter.increaseIndent();
         poetWriter.writeIndentedLine("# type: () -> Dict[str, ConjureFieldDefinition]"); // maybe....?

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/types/DefaultBeanGenerator.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/types/DefaultBeanGenerator.java
@@ -104,7 +104,7 @@ public final class DefaultBeanGenerator implements PythonBeanGenerator {
 
         return BeanSnippet.builder()
                 .className(typeDef.getTypeName().getName())
-                .addImports(BeanSnippet.CONJURE_IMPORT)
+                .addAllImports(BeanSnippet.DEFAULT_IMPORTS)
                 .addAllImports(imports)
                 .docs(typeDef.getDocs())
                 .fields(fields)

--- a/conjure-python-core/src/test/resources/services/expected/package_name/product/__init__.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/product/__init__.py
@@ -1,9 +1,9 @@
-import __builtin__
+import builtin
 from conjure_python_client import ConjureBeanType, ConjureFieldDefinition
 
 class CreateDatasetRequest(ConjureBeanType):
 
-    @__builtin__.classmethod
+    @builtin.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -19,12 +19,12 @@ class CreateDatasetRequest(ConjureBeanType):
         self._file_system_id = file_system_id
         self._path = path
 
-    @__builtin__.property
+    @builtin.property
     def file_system_id(self):
         # type: () -> str
         return self._file_system_id
 
-    @__builtin__.property
+    @builtin.property
     def path(self):
         # type: () -> str
         return self._path

--- a/conjure-python-core/src/test/resources/services/expected/package_name/product/__init__.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/product/__init__.py
@@ -1,8 +1,9 @@
+import __builtin__
 from conjure_python_client import ConjureBeanType, ConjureFieldDefinition
 
 class CreateDatasetRequest(ConjureBeanType):
 
-    @classmethod
+    @__builtin__.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -18,12 +19,12 @@ class CreateDatasetRequest(ConjureBeanType):
         self._file_system_id = file_system_id
         self._path = path
 
-    @property
+    @__builtin__.property
     def file_system_id(self):
         # type: () -> str
         return self._file_system_id
 
-    @property
+    @__builtin__.property
     def path(self):
         # type: () -> str
         return self._path

--- a/conjure-python-core/src/test/resources/services/expected/package_name/product/__init__.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/product/__init__.py
@@ -1,9 +1,9 @@
-import builtin
+import builtins
 from conjure_python_client import ConjureBeanType, ConjureFieldDefinition
 
 class CreateDatasetRequest(ConjureBeanType):
 
-    @builtin.classmethod
+    @builtins.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -19,12 +19,12 @@ class CreateDatasetRequest(ConjureBeanType):
         self._file_system_id = file_system_id
         self._path = path
 
-    @builtin.property
+    @builtins.property
     def file_system_id(self):
         # type: () -> str
         return self._file_system_id
 
-    @builtin.property
+    @builtins.property
     def path(self):
         # type: () -> str
         return self._path

--- a/conjure-python-core/src/test/resources/services/expected/package_name/product_datasets/__init__.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/product_datasets/__init__.py
@@ -1,8 +1,9 @@
+import __builtin__
 from conjure_python_client import ConjureBeanType, ConjureFieldDefinition, DictType
 
 class BackingFileSystem(ConjureBeanType):
 
-    @classmethod
+    @__builtin__.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -21,25 +22,25 @@ class BackingFileSystem(ConjureBeanType):
         self._base_uri = base_uri
         self._configuration = configuration
 
-    @property
+    @__builtin__.property
     def file_system_id(self):
         # type: () -> str
         """The name by which this file system is identified."""
         return self._file_system_id
 
-    @property
+    @__builtin__.property
     def base_uri(self):
         # type: () -> str
         return self._base_uri
 
-    @property
+    @__builtin__.property
     def configuration(self):
         # type: () -> Dict[str, str]
         return self._configuration
 
 class Dataset(ConjureBeanType):
 
-    @classmethod
+    @__builtin__.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -55,12 +56,12 @@ class Dataset(ConjureBeanType):
         self._file_system_id = file_system_id
         self._rid = rid
 
-    @property
+    @__builtin__.property
     def file_system_id(self):
         # type: () -> str
         return self._file_system_id
 
-    @property
+    @__builtin__.property
     def rid(self):
         # type: () -> str
         """Uniquely identifies this dataset."""

--- a/conjure-python-core/src/test/resources/services/expected/package_name/product_datasets/__init__.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/product_datasets/__init__.py
@@ -1,9 +1,9 @@
-import builtin
+import builtins
 from conjure_python_client import ConjureBeanType, ConjureFieldDefinition, DictType
 
 class BackingFileSystem(ConjureBeanType):
 
-    @builtin.classmethod
+    @builtins.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -22,25 +22,25 @@ class BackingFileSystem(ConjureBeanType):
         self._base_uri = base_uri
         self._configuration = configuration
 
-    @builtin.property
+    @builtins.property
     def file_system_id(self):
         # type: () -> str
         """The name by which this file system is identified."""
         return self._file_system_id
 
-    @builtin.property
+    @builtins.property
     def base_uri(self):
         # type: () -> str
         return self._base_uri
 
-    @builtin.property
+    @builtins.property
     def configuration(self):
         # type: () -> Dict[str, str]
         return self._configuration
 
 class Dataset(ConjureBeanType):
 
-    @builtin.classmethod
+    @builtins.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -56,12 +56,12 @@ class Dataset(ConjureBeanType):
         self._file_system_id = file_system_id
         self._rid = rid
 
-    @builtin.property
+    @builtins.property
     def file_system_id(self):
         # type: () -> str
         return self._file_system_id
 
-    @builtin.property
+    @builtins.property
     def rid(self):
         # type: () -> str
         """Uniquely identifies this dataset."""

--- a/conjure-python-core/src/test/resources/services/expected/package_name/product_datasets/__init__.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/product_datasets/__init__.py
@@ -1,9 +1,9 @@
-import __builtin__
+import builtin
 from conjure_python_client import ConjureBeanType, ConjureFieldDefinition, DictType
 
 class BackingFileSystem(ConjureBeanType):
 
-    @__builtin__.classmethod
+    @builtin.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -22,25 +22,25 @@ class BackingFileSystem(ConjureBeanType):
         self._base_uri = base_uri
         self._configuration = configuration
 
-    @__builtin__.property
+    @builtin.property
     def file_system_id(self):
         # type: () -> str
         """The name by which this file system is identified."""
         return self._file_system_id
 
-    @__builtin__.property
+    @builtin.property
     def base_uri(self):
         # type: () -> str
         return self._base_uri
 
-    @__builtin__.property
+    @builtin.property
     def configuration(self):
         # type: () -> Dict[str, str]
         return self._configuration
 
 class Dataset(ConjureBeanType):
 
-    @__builtin__.classmethod
+    @builtin.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -56,12 +56,12 @@ class Dataset(ConjureBeanType):
         self._file_system_id = file_system_id
         self._rid = rid
 
-    @__builtin__.property
+    @builtin.property
     def file_system_id(self):
         # type: () -> str
         return self._file_system_id
 
-    @__builtin__.property
+    @builtin.property
     def rid(self):
         # type: () -> str
         """Uniquely identifies this dataset."""

--- a/conjure-python-core/src/test/resources/services/expected/setup.py
+++ b/conjure-python-core/src/test/resources/services/expected/setup.py
@@ -9,5 +9,6 @@ setup(
         'requests',
         'typing',
         'conjure-python-client>=1.0.0,<2',
+        'future',
     ],
 )

--- a/conjure-python-core/src/test/resources/types/expected/package_name/nested_service/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/nested_service/__init__.py
@@ -1,3 +1,4 @@
+import __builtin__
 from conjure_python_client import ConjureBeanType, ConjureDecoder, ConjureEncoder, ConjureFieldDefinition, Service
 
 class SimpleNestedService(Service):
@@ -33,7 +34,7 @@ class SimpleNestedService(Service):
 
 class SimpleObject(ConjureBeanType):
 
-    @classmethod
+    @__builtin__.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -46,7 +47,7 @@ class SimpleObject(ConjureBeanType):
         # type: (str) -> None
         self._string = string
 
-    @property
+    @__builtin__.property
     def string(self):
         # type: () -> str
         return self._string

--- a/conjure-python-core/src/test/resources/types/expected/package_name/nested_service/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/nested_service/__init__.py
@@ -1,4 +1,4 @@
-import builtin
+import builtins
 from conjure_python_client import ConjureBeanType, ConjureDecoder, ConjureEncoder, ConjureFieldDefinition, Service
 
 class SimpleNestedService(Service):
@@ -34,7 +34,7 @@ class SimpleNestedService(Service):
 
 class SimpleObject(ConjureBeanType):
 
-    @builtin.classmethod
+    @builtins.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -47,7 +47,7 @@ class SimpleObject(ConjureBeanType):
         # type: (str) -> None
         self._string = string
 
-    @builtin.property
+    @builtins.property
     def string(self):
         # type: () -> str
         return self._string

--- a/conjure-python-core/src/test/resources/types/expected/package_name/nested_service/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/nested_service/__init__.py
@@ -1,4 +1,4 @@
-import __builtin__
+import builtin
 from conjure_python_client import ConjureBeanType, ConjureDecoder, ConjureEncoder, ConjureFieldDefinition, Service
 
 class SimpleNestedService(Service):
@@ -34,7 +34,7 @@ class SimpleNestedService(Service):
 
 class SimpleObject(ConjureBeanType):
 
-    @__builtin__.classmethod
+    @builtin.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -47,7 +47,7 @@ class SimpleObject(ConjureBeanType):
         # type: (str) -> None
         self._string = string
 
-    @__builtin__.property
+    @builtin.property
     def string(self):
         # type: () -> str
         return self._string

--- a/conjure-python-core/src/test/resources/types/expected/package_name/product/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/product/__init__.py
@@ -1,11 +1,11 @@
 from abc import ABCMeta, abstractmethod
-import builtin
+import builtins
 from conjure_python_client import BinaryType, ConjureBeanType, ConjureEnumType, ConjureFieldDefinition, ConjureUnionType, DictType, ListType, OptionalType
 from typing import Any, List, Optional, Set
 
 class AliasAsMapKeyExample(ConjureBeanType):
 
-    @builtin.classmethod
+    @builtins.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -36,44 +36,44 @@ class AliasAsMapKeyExample(ConjureBeanType):
         self._datetimes = datetimes
         self._uuids = uuids
 
-    @builtin.property
+    @builtins.property
     def strings(self):
         # type: () -> Dict[StringAliasExample, ManyFieldExample]
         return self._strings
 
-    @builtin.property
+    @builtins.property
     def rids(self):
         # type: () -> Dict[RidAliasExample, ManyFieldExample]
         return self._rids
 
-    @builtin.property
+    @builtins.property
     def bearertokens(self):
         # type: () -> Dict[BearerTokenAliasExample, ManyFieldExample]
         return self._bearertokens
 
-    @builtin.property
+    @builtins.property
     def integers(self):
         # type: () -> Dict[IntegerAliasExample, ManyFieldExample]
         return self._integers
 
-    @builtin.property
+    @builtins.property
     def safelongs(self):
         # type: () -> Dict[SafeLongAliasExample, ManyFieldExample]
         return self._safelongs
 
-    @builtin.property
+    @builtins.property
     def datetimes(self):
         # type: () -> Dict[DateTimeAliasExample, ManyFieldExample]
         return self._datetimes
 
-    @builtin.property
+    @builtins.property
     def uuids(self):
         # type: () -> Dict[UuidAliasExample, ManyFieldExample]
         return self._uuids
 
 class AnyExample(ConjureBeanType):
 
-    @builtin.classmethod
+    @builtins.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -86,14 +86,14 @@ class AnyExample(ConjureBeanType):
         # type: (Any) -> None
         self._any = any
 
-    @builtin.property
+    @builtins.property
     def any(self):
         # type: () -> Any
         return self._any
 
 class AnyMapExample(ConjureBeanType):
 
-    @builtin.classmethod
+    @builtins.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -106,14 +106,14 @@ class AnyMapExample(ConjureBeanType):
         # type: (Dict[str, Any]) -> None
         self._items = items
 
-    @builtin.property
+    @builtins.property
     def items(self):
         # type: () -> Dict[str, Any]
         return self._items
 
 class BearerTokenExample(ConjureBeanType):
 
-    @builtin.classmethod
+    @builtins.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -126,14 +126,14 @@ class BearerTokenExample(ConjureBeanType):
         # type: (str) -> None
         self._bearer_token_value = bearer_token_value
 
-    @builtin.property
+    @builtins.property
     def bearer_token_value(self):
         # type: () -> str
         return self._bearer_token_value
 
 class BinaryExample(ConjureBeanType):
 
-    @builtin.classmethod
+    @builtins.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -146,14 +146,14 @@ class BinaryExample(ConjureBeanType):
         # type: (Any) -> None
         self._binary = binary
 
-    @builtin.property
+    @builtins.property
     def binary(self):
         # type: () -> Any
         return self._binary
 
 class BooleanExample(ConjureBeanType):
 
-    @builtin.classmethod
+    @builtins.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -166,14 +166,14 @@ class BooleanExample(ConjureBeanType):
         # type: (bool) -> None
         self._coin = coin
 
-    @builtin.property
+    @builtins.property
     def coin(self):
         # type: () -> bool
         return self._coin
 
 class CreateDatasetRequest(ConjureBeanType):
 
-    @builtin.classmethod
+    @builtins.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -189,19 +189,19 @@ class CreateDatasetRequest(ConjureBeanType):
         self._file_system_id = file_system_id
         self._path = path
 
-    @builtin.property
+    @builtins.property
     def file_system_id(self):
         # type: () -> str
         return self._file_system_id
 
-    @builtin.property
+    @builtins.property
     def path(self):
         # type: () -> str
         return self._path
 
 class DateTimeExample(ConjureBeanType):
 
-    @builtin.classmethod
+    @builtins.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -214,14 +214,14 @@ class DateTimeExample(ConjureBeanType):
         # type: (str) -> None
         self._datetime = datetime
 
-    @builtin.property
+    @builtins.property
     def datetime(self):
         # type: () -> str
         return self._datetime
 
 class DoubleExample(ConjureBeanType):
 
-    @builtin.classmethod
+    @builtins.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -234,14 +234,14 @@ class DoubleExample(ConjureBeanType):
         # type: (float) -> None
         self._double_value = double_value
 
-    @builtin.property
+    @builtins.property
     def double_value(self):
         # type: () -> float
         return self._double_value
 
 class EmptyObjectExample(ConjureBeanType):
 
-    @builtin.classmethod
+    @builtins.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -264,7 +264,7 @@ class EnumExample(ConjureEnumType):
 
 class EnumFieldExample(ConjureBeanType):
 
-    @builtin.classmethod
+    @builtins.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -277,14 +277,14 @@ class EnumFieldExample(ConjureBeanType):
         # type: (EnumExample) -> None
         self._enum = enum
 
-    @builtin.property
+    @builtins.property
     def enum(self):
         # type: () -> EnumExample
         return self._enum
 
 class IntegerExample(ConjureBeanType):
 
-    @builtin.classmethod
+    @builtins.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -297,14 +297,14 @@ class IntegerExample(ConjureBeanType):
         # type: (int) -> None
         self._integer = integer
 
-    @builtin.property
+    @builtins.property
     def integer(self):
         # type: () -> int
         return self._integer
 
 class ListExample(ConjureBeanType):
 
-    @builtin.classmethod
+    @builtins.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -323,24 +323,24 @@ class ListExample(ConjureBeanType):
         self._primitive_items = primitive_items
         self._double_items = double_items
 
-    @builtin.property
+    @builtins.property
     def items(self):
         # type: () -> List[str]
         return self._items
 
-    @builtin.property
+    @builtins.property
     def primitive_items(self):
         # type: () -> List[int]
         return self._primitive_items
 
-    @builtin.property
+    @builtins.property
     def double_items(self):
         # type: () -> List[float]
         return self._double_items
 
 class ManyFieldExample(ConjureBeanType):
 
-    @builtin.classmethod
+    @builtins.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -374,49 +374,49 @@ class ManyFieldExample(ConjureBeanType):
         self._map = map
         self._alias = alias
 
-    @builtin.property
+    @builtins.property
     def string(self):
         # type: () -> str
         """docs for string field"""
         return self._string
 
-    @builtin.property
+    @builtins.property
     def integer(self):
         # type: () -> int
         """docs for integer field"""
         return self._integer
 
-    @builtin.property
+    @builtins.property
     def double_value(self):
         # type: () -> float
         """docs for doubleValue field"""
         return self._double_value
 
-    @builtin.property
+    @builtins.property
     def optional_item(self):
         # type: () -> Optional[str]
         """docs for optionalItem field"""
         return self._optional_item
 
-    @builtin.property
+    @builtins.property
     def items(self):
         # type: () -> List[str]
         """docs for items field"""
         return self._items
 
-    @builtin.property
+    @builtins.property
     def set(self):
         # type: () -> List[str]
         """docs for set field"""
         return self._set
 
-    @builtin.property
+    @builtins.property
     def map(self):
         # type: () -> Dict[str, str]
         """docs for map field"""
         return self._map
 
-    @builtin.property
+    @builtins.property
     def alias(self):
         # type: () -> StringAliasExample
         """docs for alias field"""
@@ -424,7 +424,7 @@ class ManyFieldExample(ConjureBeanType):
 
 class MapExample(ConjureBeanType):
 
-    @builtin.classmethod
+    @builtins.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -437,14 +437,14 @@ class MapExample(ConjureBeanType):
         # type: (Dict[str, str]) -> None
         self._items = items
 
-    @builtin.property
+    @builtins.property
     def items(self):
         # type: () -> Dict[str, str]
         return self._items
 
 class OptionalExample(ConjureBeanType):
 
-    @builtin.classmethod
+    @builtins.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -457,14 +457,14 @@ class OptionalExample(ConjureBeanType):
         # type: (Optional[str]) -> None
         self._item = item
 
-    @builtin.property
+    @builtins.property
     def item(self):
         # type: () -> Optional[str]
         return self._item
 
 class PrimitiveOptionalsExample(ConjureBeanType):
 
-    @builtin.classmethod
+    @builtins.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -495,44 +495,44 @@ class PrimitiveOptionalsExample(ConjureBeanType):
         self._bearertoken = bearertoken
         self._uuid = uuid
 
-    @builtin.property
+    @builtins.property
     def num(self):
         # type: () -> Optional[float]
         return self._num
 
-    @builtin.property
+    @builtins.property
     def bool(self):
         # type: () -> Optional[bool]
         return self._bool
 
-    @builtin.property
+    @builtins.property
     def integer(self):
         # type: () -> Optional[int]
         return self._integer
 
-    @builtin.property
+    @builtins.property
     def safelong(self):
         # type: () -> Optional[int]
         return self._safelong
 
-    @builtin.property
+    @builtins.property
     def rid(self):
         # type: () -> Optional[str]
         return self._rid
 
-    @builtin.property
+    @builtins.property
     def bearertoken(self):
         # type: () -> Optional[str]
         return self._bearertoken
 
-    @builtin.property
+    @builtins.property
     def uuid(self):
         # type: () -> Optional[str]
         return self._uuid
 
 class RecursiveObjectExample(ConjureBeanType):
 
-    @builtin.classmethod
+    @builtins.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -545,14 +545,14 @@ class RecursiveObjectExample(ConjureBeanType):
         # type: (Optional[RecursiveObjectAlias]) -> None
         self._recursive_field = recursive_field
 
-    @builtin.property
+    @builtins.property
     def recursive_field(self):
         # type: () -> Optional[RecursiveObjectAlias]
         return self._recursive_field
 
 class ReservedKeyExample(ConjureBeanType):
 
-    @builtin.classmethod
+    @builtins.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -574,29 +574,29 @@ class ReservedKeyExample(ConjureBeanType):
         self._field_name_with_dashes = field_name_with_dashes
         self._memoized_hash_code = memoized_hash_code
 
-    @builtin.property
+    @builtins.property
     def package(self):
         # type: () -> str
         return self._package
 
-    @builtin.property
+    @builtins.property
     def interface(self):
         # type: () -> str
         return self._interface
 
-    @builtin.property
+    @builtins.property
     def field_name_with_dashes(self):
         # type: () -> str
         return self._field_name_with_dashes
 
-    @builtin.property
+    @builtins.property
     def memoized_hash_code(self):
         # type: () -> int
         return self._memoized_hash_code
 
 class RidExample(ConjureBeanType):
 
-    @builtin.classmethod
+    @builtins.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -609,14 +609,14 @@ class RidExample(ConjureBeanType):
         # type: (str) -> None
         self._rid_value = rid_value
 
-    @builtin.property
+    @builtins.property
     def rid_value(self):
         # type: () -> str
         return self._rid_value
 
 class SafeLongExample(ConjureBeanType):
 
-    @builtin.classmethod
+    @builtins.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -629,14 +629,14 @@ class SafeLongExample(ConjureBeanType):
         # type: (int) -> None
         self._safe_long_value = safe_long_value
 
-    @builtin.property
+    @builtins.property
     def safe_long_value(self):
         # type: () -> int
         return self._safe_long_value
 
 class SetExample(ConjureBeanType):
 
-    @builtin.classmethod
+    @builtins.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -652,19 +652,19 @@ class SetExample(ConjureBeanType):
         self._items = items
         self._double_items = double_items
 
-    @builtin.property
+    @builtins.property
     def items(self):
         # type: () -> List[str]
         return self._items
 
-    @builtin.property
+    @builtins.property
     def double_items(self):
         # type: () -> List[float]
         return self._double_items
 
 class StringExample(ConjureBeanType):
 
-    @builtin.classmethod
+    @builtins.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -677,7 +677,7 @@ class StringExample(ConjureBeanType):
         # type: (str) -> None
         self._string = string
 
-    @builtin.property
+    @builtins.property
     def string(self):
         # type: () -> str
         return self._string
@@ -693,7 +693,7 @@ class UnionTypeExample(ConjureUnionType):
     _new = None # type: int
     _interface = None # type: int
 
-    @builtin.classmethod
+    @builtins.classmethod
     def _options(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -828,7 +828,7 @@ class UnionTypeExampleVisitor(ABCMeta('ABC', (object,), {})):
 
 class UuidExample(ConjureBeanType):
 
-    @builtin.classmethod
+    @builtins.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -841,7 +841,7 @@ class UuidExample(ConjureBeanType):
         # type: (str) -> None
         self._uuid = uuid
 
-    @builtin.property
+    @builtins.property
     def uuid(self):
         # type: () -> str
         return self._uuid

--- a/conjure-python-core/src/test/resources/types/expected/package_name/product/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/product/__init__.py
@@ -1,10 +1,11 @@
+import __builtin__
 from abc import ABCMeta, abstractmethod
 from conjure_python_client import BinaryType, ConjureBeanType, ConjureEnumType, ConjureFieldDefinition, ConjureUnionType, DictType, ListType, OptionalType
 from typing import Any, List, Optional, Set
 
 class AliasAsMapKeyExample(ConjureBeanType):
 
-    @classmethod
+    @__builtin__.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -35,44 +36,44 @@ class AliasAsMapKeyExample(ConjureBeanType):
         self._datetimes = datetimes
         self._uuids = uuids
 
-    @property
+    @__builtin__.property
     def strings(self):
         # type: () -> Dict[StringAliasExample, ManyFieldExample]
         return self._strings
 
-    @property
+    @__builtin__.property
     def rids(self):
         # type: () -> Dict[RidAliasExample, ManyFieldExample]
         return self._rids
 
-    @property
+    @__builtin__.property
     def bearertokens(self):
         # type: () -> Dict[BearerTokenAliasExample, ManyFieldExample]
         return self._bearertokens
 
-    @property
+    @__builtin__.property
     def integers(self):
         # type: () -> Dict[IntegerAliasExample, ManyFieldExample]
         return self._integers
 
-    @property
+    @__builtin__.property
     def safelongs(self):
         # type: () -> Dict[SafeLongAliasExample, ManyFieldExample]
         return self._safelongs
 
-    @property
+    @__builtin__.property
     def datetimes(self):
         # type: () -> Dict[DateTimeAliasExample, ManyFieldExample]
         return self._datetimes
 
-    @property
+    @__builtin__.property
     def uuids(self):
         # type: () -> Dict[UuidAliasExample, ManyFieldExample]
         return self._uuids
 
 class AnyExample(ConjureBeanType):
 
-    @classmethod
+    @__builtin__.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -85,14 +86,14 @@ class AnyExample(ConjureBeanType):
         # type: (Any) -> None
         self._any = any
 
-    @property
+    @__builtin__.property
     def any(self):
         # type: () -> Any
         return self._any
 
 class AnyMapExample(ConjureBeanType):
 
-    @classmethod
+    @__builtin__.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -105,14 +106,14 @@ class AnyMapExample(ConjureBeanType):
         # type: (Dict[str, Any]) -> None
         self._items = items
 
-    @property
+    @__builtin__.property
     def items(self):
         # type: () -> Dict[str, Any]
         return self._items
 
 class BearerTokenExample(ConjureBeanType):
 
-    @classmethod
+    @__builtin__.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -125,14 +126,14 @@ class BearerTokenExample(ConjureBeanType):
         # type: (str) -> None
         self._bearer_token_value = bearer_token_value
 
-    @property
+    @__builtin__.property
     def bearer_token_value(self):
         # type: () -> str
         return self._bearer_token_value
 
 class BinaryExample(ConjureBeanType):
 
-    @classmethod
+    @__builtin__.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -145,14 +146,14 @@ class BinaryExample(ConjureBeanType):
         # type: (Any) -> None
         self._binary = binary
 
-    @property
+    @__builtin__.property
     def binary(self):
         # type: () -> Any
         return self._binary
 
 class BooleanExample(ConjureBeanType):
 
-    @classmethod
+    @__builtin__.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -165,14 +166,14 @@ class BooleanExample(ConjureBeanType):
         # type: (bool) -> None
         self._coin = coin
 
-    @property
+    @__builtin__.property
     def coin(self):
         # type: () -> bool
         return self._coin
 
 class CreateDatasetRequest(ConjureBeanType):
 
-    @classmethod
+    @__builtin__.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -188,19 +189,19 @@ class CreateDatasetRequest(ConjureBeanType):
         self._file_system_id = file_system_id
         self._path = path
 
-    @property
+    @__builtin__.property
     def file_system_id(self):
         # type: () -> str
         return self._file_system_id
 
-    @property
+    @__builtin__.property
     def path(self):
         # type: () -> str
         return self._path
 
 class DateTimeExample(ConjureBeanType):
 
-    @classmethod
+    @__builtin__.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -213,14 +214,14 @@ class DateTimeExample(ConjureBeanType):
         # type: (str) -> None
         self._datetime = datetime
 
-    @property
+    @__builtin__.property
     def datetime(self):
         # type: () -> str
         return self._datetime
 
 class DoubleExample(ConjureBeanType):
 
-    @classmethod
+    @__builtin__.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -233,14 +234,14 @@ class DoubleExample(ConjureBeanType):
         # type: (float) -> None
         self._double_value = double_value
 
-    @property
+    @__builtin__.property
     def double_value(self):
         # type: () -> float
         return self._double_value
 
 class EmptyObjectExample(ConjureBeanType):
 
-    @classmethod
+    @__builtin__.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -263,7 +264,7 @@ class EnumExample(ConjureEnumType):
 
 class EnumFieldExample(ConjureBeanType):
 
-    @classmethod
+    @__builtin__.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -276,14 +277,14 @@ class EnumFieldExample(ConjureBeanType):
         # type: (EnumExample) -> None
         self._enum = enum
 
-    @property
+    @__builtin__.property
     def enum(self):
         # type: () -> EnumExample
         return self._enum
 
 class IntegerExample(ConjureBeanType):
 
-    @classmethod
+    @__builtin__.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -296,14 +297,14 @@ class IntegerExample(ConjureBeanType):
         # type: (int) -> None
         self._integer = integer
 
-    @property
+    @__builtin__.property
     def integer(self):
         # type: () -> int
         return self._integer
 
 class ListExample(ConjureBeanType):
 
-    @classmethod
+    @__builtin__.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -322,24 +323,24 @@ class ListExample(ConjureBeanType):
         self._primitive_items = primitive_items
         self._double_items = double_items
 
-    @property
+    @__builtin__.property
     def items(self):
         # type: () -> List[str]
         return self._items
 
-    @property
+    @__builtin__.property
     def primitive_items(self):
         # type: () -> List[int]
         return self._primitive_items
 
-    @property
+    @__builtin__.property
     def double_items(self):
         # type: () -> List[float]
         return self._double_items
 
 class ManyFieldExample(ConjureBeanType):
 
-    @classmethod
+    @__builtin__.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -373,49 +374,49 @@ class ManyFieldExample(ConjureBeanType):
         self._map = map
         self._alias = alias
 
-    @property
+    @__builtin__.property
     def string(self):
         # type: () -> str
         """docs for string field"""
         return self._string
 
-    @property
+    @__builtin__.property
     def integer(self):
         # type: () -> int
         """docs for integer field"""
         return self._integer
 
-    @property
+    @__builtin__.property
     def double_value(self):
         # type: () -> float
         """docs for doubleValue field"""
         return self._double_value
 
-    @property
+    @__builtin__.property
     def optional_item(self):
         # type: () -> Optional[str]
         """docs for optionalItem field"""
         return self._optional_item
 
-    @property
+    @__builtin__.property
     def items(self):
         # type: () -> List[str]
         """docs for items field"""
         return self._items
 
-    @property
+    @__builtin__.property
     def set(self):
         # type: () -> List[str]
         """docs for set field"""
         return self._set
 
-    @property
+    @__builtin__.property
     def map(self):
         # type: () -> Dict[str, str]
         """docs for map field"""
         return self._map
 
-    @property
+    @__builtin__.property
     def alias(self):
         # type: () -> StringAliasExample
         """docs for alias field"""
@@ -423,7 +424,7 @@ class ManyFieldExample(ConjureBeanType):
 
 class MapExample(ConjureBeanType):
 
-    @classmethod
+    @__builtin__.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -436,14 +437,14 @@ class MapExample(ConjureBeanType):
         # type: (Dict[str, str]) -> None
         self._items = items
 
-    @property
+    @__builtin__.property
     def items(self):
         # type: () -> Dict[str, str]
         return self._items
 
 class OptionalExample(ConjureBeanType):
 
-    @classmethod
+    @__builtin__.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -456,14 +457,14 @@ class OptionalExample(ConjureBeanType):
         # type: (Optional[str]) -> None
         self._item = item
 
-    @property
+    @__builtin__.property
     def item(self):
         # type: () -> Optional[str]
         return self._item
 
 class PrimitiveOptionalsExample(ConjureBeanType):
 
-    @classmethod
+    @__builtin__.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -494,44 +495,44 @@ class PrimitiveOptionalsExample(ConjureBeanType):
         self._bearertoken = bearertoken
         self._uuid = uuid
 
-    @property
+    @__builtin__.property
     def num(self):
         # type: () -> Optional[float]
         return self._num
 
-    @property
+    @__builtin__.property
     def bool(self):
         # type: () -> Optional[bool]
         return self._bool
 
-    @property
+    @__builtin__.property
     def integer(self):
         # type: () -> Optional[int]
         return self._integer
 
-    @property
+    @__builtin__.property
     def safelong(self):
         # type: () -> Optional[int]
         return self._safelong
 
-    @property
+    @__builtin__.property
     def rid(self):
         # type: () -> Optional[str]
         return self._rid
 
-    @property
+    @__builtin__.property
     def bearertoken(self):
         # type: () -> Optional[str]
         return self._bearertoken
 
-    @property
+    @__builtin__.property
     def uuid(self):
         # type: () -> Optional[str]
         return self._uuid
 
 class RecursiveObjectExample(ConjureBeanType):
 
-    @classmethod
+    @__builtin__.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -544,14 +545,14 @@ class RecursiveObjectExample(ConjureBeanType):
         # type: (Optional[RecursiveObjectAlias]) -> None
         self._recursive_field = recursive_field
 
-    @property
+    @__builtin__.property
     def recursive_field(self):
         # type: () -> Optional[RecursiveObjectAlias]
         return self._recursive_field
 
 class ReservedKeyExample(ConjureBeanType):
 
-    @classmethod
+    @__builtin__.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -573,29 +574,29 @@ class ReservedKeyExample(ConjureBeanType):
         self._field_name_with_dashes = field_name_with_dashes
         self._memoized_hash_code = memoized_hash_code
 
-    @property
+    @__builtin__.property
     def package(self):
         # type: () -> str
         return self._package
 
-    @property
+    @__builtin__.property
     def interface(self):
         # type: () -> str
         return self._interface
 
-    @property
+    @__builtin__.property
     def field_name_with_dashes(self):
         # type: () -> str
         return self._field_name_with_dashes
 
-    @property
+    @__builtin__.property
     def memoized_hash_code(self):
         # type: () -> int
         return self._memoized_hash_code
 
 class RidExample(ConjureBeanType):
 
-    @classmethod
+    @__builtin__.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -608,14 +609,14 @@ class RidExample(ConjureBeanType):
         # type: (str) -> None
         self._rid_value = rid_value
 
-    @property
+    @__builtin__.property
     def rid_value(self):
         # type: () -> str
         return self._rid_value
 
 class SafeLongExample(ConjureBeanType):
 
-    @classmethod
+    @__builtin__.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -628,14 +629,14 @@ class SafeLongExample(ConjureBeanType):
         # type: (int) -> None
         self._safe_long_value = safe_long_value
 
-    @property
+    @__builtin__.property
     def safe_long_value(self):
         # type: () -> int
         return self._safe_long_value
 
 class SetExample(ConjureBeanType):
 
-    @classmethod
+    @__builtin__.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -651,19 +652,19 @@ class SetExample(ConjureBeanType):
         self._items = items
         self._double_items = double_items
 
-    @property
+    @__builtin__.property
     def items(self):
         # type: () -> List[str]
         return self._items
 
-    @property
+    @__builtin__.property
     def double_items(self):
         # type: () -> List[float]
         return self._double_items
 
 class StringExample(ConjureBeanType):
 
-    @classmethod
+    @__builtin__.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -676,7 +677,7 @@ class StringExample(ConjureBeanType):
         # type: (str) -> None
         self._string = string
 
-    @property
+    @__builtin__.property
     def string(self):
         # type: () -> str
         return self._string
@@ -692,7 +693,7 @@ class UnionTypeExample(ConjureUnionType):
     _new = None # type: int
     _interface = None # type: int
 
-    @classmethod
+    @__builtin__.classmethod
     def _options(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -827,7 +828,7 @@ class UnionTypeExampleVisitor(ABCMeta('ABC', (object,), {})):
 
 class UuidExample(ConjureBeanType):
 
-    @classmethod
+    @__builtin__.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -840,7 +841,7 @@ class UuidExample(ConjureBeanType):
         # type: (str) -> None
         self._uuid = uuid
 
-    @property
+    @__builtin__.property
     def uuid(self):
         # type: () -> str
         return self._uuid

--- a/conjure-python-core/src/test/resources/types/expected/package_name/product/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/product/__init__.py
@@ -1,11 +1,11 @@
-import __builtin__
 from abc import ABCMeta, abstractmethod
+import builtin
 from conjure_python_client import BinaryType, ConjureBeanType, ConjureEnumType, ConjureFieldDefinition, ConjureUnionType, DictType, ListType, OptionalType
 from typing import Any, List, Optional, Set
 
 class AliasAsMapKeyExample(ConjureBeanType):
 
-    @__builtin__.classmethod
+    @builtin.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -36,44 +36,44 @@ class AliasAsMapKeyExample(ConjureBeanType):
         self._datetimes = datetimes
         self._uuids = uuids
 
-    @__builtin__.property
+    @builtin.property
     def strings(self):
         # type: () -> Dict[StringAliasExample, ManyFieldExample]
         return self._strings
 
-    @__builtin__.property
+    @builtin.property
     def rids(self):
         # type: () -> Dict[RidAliasExample, ManyFieldExample]
         return self._rids
 
-    @__builtin__.property
+    @builtin.property
     def bearertokens(self):
         # type: () -> Dict[BearerTokenAliasExample, ManyFieldExample]
         return self._bearertokens
 
-    @__builtin__.property
+    @builtin.property
     def integers(self):
         # type: () -> Dict[IntegerAliasExample, ManyFieldExample]
         return self._integers
 
-    @__builtin__.property
+    @builtin.property
     def safelongs(self):
         # type: () -> Dict[SafeLongAliasExample, ManyFieldExample]
         return self._safelongs
 
-    @__builtin__.property
+    @builtin.property
     def datetimes(self):
         # type: () -> Dict[DateTimeAliasExample, ManyFieldExample]
         return self._datetimes
 
-    @__builtin__.property
+    @builtin.property
     def uuids(self):
         # type: () -> Dict[UuidAliasExample, ManyFieldExample]
         return self._uuids
 
 class AnyExample(ConjureBeanType):
 
-    @__builtin__.classmethod
+    @builtin.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -86,14 +86,14 @@ class AnyExample(ConjureBeanType):
         # type: (Any) -> None
         self._any = any
 
-    @__builtin__.property
+    @builtin.property
     def any(self):
         # type: () -> Any
         return self._any
 
 class AnyMapExample(ConjureBeanType):
 
-    @__builtin__.classmethod
+    @builtin.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -106,14 +106,14 @@ class AnyMapExample(ConjureBeanType):
         # type: (Dict[str, Any]) -> None
         self._items = items
 
-    @__builtin__.property
+    @builtin.property
     def items(self):
         # type: () -> Dict[str, Any]
         return self._items
 
 class BearerTokenExample(ConjureBeanType):
 
-    @__builtin__.classmethod
+    @builtin.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -126,14 +126,14 @@ class BearerTokenExample(ConjureBeanType):
         # type: (str) -> None
         self._bearer_token_value = bearer_token_value
 
-    @__builtin__.property
+    @builtin.property
     def bearer_token_value(self):
         # type: () -> str
         return self._bearer_token_value
 
 class BinaryExample(ConjureBeanType):
 
-    @__builtin__.classmethod
+    @builtin.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -146,14 +146,14 @@ class BinaryExample(ConjureBeanType):
         # type: (Any) -> None
         self._binary = binary
 
-    @__builtin__.property
+    @builtin.property
     def binary(self):
         # type: () -> Any
         return self._binary
 
 class BooleanExample(ConjureBeanType):
 
-    @__builtin__.classmethod
+    @builtin.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -166,14 +166,14 @@ class BooleanExample(ConjureBeanType):
         # type: (bool) -> None
         self._coin = coin
 
-    @__builtin__.property
+    @builtin.property
     def coin(self):
         # type: () -> bool
         return self._coin
 
 class CreateDatasetRequest(ConjureBeanType):
 
-    @__builtin__.classmethod
+    @builtin.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -189,19 +189,19 @@ class CreateDatasetRequest(ConjureBeanType):
         self._file_system_id = file_system_id
         self._path = path
 
-    @__builtin__.property
+    @builtin.property
     def file_system_id(self):
         # type: () -> str
         return self._file_system_id
 
-    @__builtin__.property
+    @builtin.property
     def path(self):
         # type: () -> str
         return self._path
 
 class DateTimeExample(ConjureBeanType):
 
-    @__builtin__.classmethod
+    @builtin.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -214,14 +214,14 @@ class DateTimeExample(ConjureBeanType):
         # type: (str) -> None
         self._datetime = datetime
 
-    @__builtin__.property
+    @builtin.property
     def datetime(self):
         # type: () -> str
         return self._datetime
 
 class DoubleExample(ConjureBeanType):
 
-    @__builtin__.classmethod
+    @builtin.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -234,14 +234,14 @@ class DoubleExample(ConjureBeanType):
         # type: (float) -> None
         self._double_value = double_value
 
-    @__builtin__.property
+    @builtin.property
     def double_value(self):
         # type: () -> float
         return self._double_value
 
 class EmptyObjectExample(ConjureBeanType):
 
-    @__builtin__.classmethod
+    @builtin.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -264,7 +264,7 @@ class EnumExample(ConjureEnumType):
 
 class EnumFieldExample(ConjureBeanType):
 
-    @__builtin__.classmethod
+    @builtin.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -277,14 +277,14 @@ class EnumFieldExample(ConjureBeanType):
         # type: (EnumExample) -> None
         self._enum = enum
 
-    @__builtin__.property
+    @builtin.property
     def enum(self):
         # type: () -> EnumExample
         return self._enum
 
 class IntegerExample(ConjureBeanType):
 
-    @__builtin__.classmethod
+    @builtin.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -297,14 +297,14 @@ class IntegerExample(ConjureBeanType):
         # type: (int) -> None
         self._integer = integer
 
-    @__builtin__.property
+    @builtin.property
     def integer(self):
         # type: () -> int
         return self._integer
 
 class ListExample(ConjureBeanType):
 
-    @__builtin__.classmethod
+    @builtin.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -323,24 +323,24 @@ class ListExample(ConjureBeanType):
         self._primitive_items = primitive_items
         self._double_items = double_items
 
-    @__builtin__.property
+    @builtin.property
     def items(self):
         # type: () -> List[str]
         return self._items
 
-    @__builtin__.property
+    @builtin.property
     def primitive_items(self):
         # type: () -> List[int]
         return self._primitive_items
 
-    @__builtin__.property
+    @builtin.property
     def double_items(self):
         # type: () -> List[float]
         return self._double_items
 
 class ManyFieldExample(ConjureBeanType):
 
-    @__builtin__.classmethod
+    @builtin.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -374,49 +374,49 @@ class ManyFieldExample(ConjureBeanType):
         self._map = map
         self._alias = alias
 
-    @__builtin__.property
+    @builtin.property
     def string(self):
         # type: () -> str
         """docs for string field"""
         return self._string
 
-    @__builtin__.property
+    @builtin.property
     def integer(self):
         # type: () -> int
         """docs for integer field"""
         return self._integer
 
-    @__builtin__.property
+    @builtin.property
     def double_value(self):
         # type: () -> float
         """docs for doubleValue field"""
         return self._double_value
 
-    @__builtin__.property
+    @builtin.property
     def optional_item(self):
         # type: () -> Optional[str]
         """docs for optionalItem field"""
         return self._optional_item
 
-    @__builtin__.property
+    @builtin.property
     def items(self):
         # type: () -> List[str]
         """docs for items field"""
         return self._items
 
-    @__builtin__.property
+    @builtin.property
     def set(self):
         # type: () -> List[str]
         """docs for set field"""
         return self._set
 
-    @__builtin__.property
+    @builtin.property
     def map(self):
         # type: () -> Dict[str, str]
         """docs for map field"""
         return self._map
 
-    @__builtin__.property
+    @builtin.property
     def alias(self):
         # type: () -> StringAliasExample
         """docs for alias field"""
@@ -424,7 +424,7 @@ class ManyFieldExample(ConjureBeanType):
 
 class MapExample(ConjureBeanType):
 
-    @__builtin__.classmethod
+    @builtin.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -437,14 +437,14 @@ class MapExample(ConjureBeanType):
         # type: (Dict[str, str]) -> None
         self._items = items
 
-    @__builtin__.property
+    @builtin.property
     def items(self):
         # type: () -> Dict[str, str]
         return self._items
 
 class OptionalExample(ConjureBeanType):
 
-    @__builtin__.classmethod
+    @builtin.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -457,14 +457,14 @@ class OptionalExample(ConjureBeanType):
         # type: (Optional[str]) -> None
         self._item = item
 
-    @__builtin__.property
+    @builtin.property
     def item(self):
         # type: () -> Optional[str]
         return self._item
 
 class PrimitiveOptionalsExample(ConjureBeanType):
 
-    @__builtin__.classmethod
+    @builtin.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -495,44 +495,44 @@ class PrimitiveOptionalsExample(ConjureBeanType):
         self._bearertoken = bearertoken
         self._uuid = uuid
 
-    @__builtin__.property
+    @builtin.property
     def num(self):
         # type: () -> Optional[float]
         return self._num
 
-    @__builtin__.property
+    @builtin.property
     def bool(self):
         # type: () -> Optional[bool]
         return self._bool
 
-    @__builtin__.property
+    @builtin.property
     def integer(self):
         # type: () -> Optional[int]
         return self._integer
 
-    @__builtin__.property
+    @builtin.property
     def safelong(self):
         # type: () -> Optional[int]
         return self._safelong
 
-    @__builtin__.property
+    @builtin.property
     def rid(self):
         # type: () -> Optional[str]
         return self._rid
 
-    @__builtin__.property
+    @builtin.property
     def bearertoken(self):
         # type: () -> Optional[str]
         return self._bearertoken
 
-    @__builtin__.property
+    @builtin.property
     def uuid(self):
         # type: () -> Optional[str]
         return self._uuid
 
 class RecursiveObjectExample(ConjureBeanType):
 
-    @__builtin__.classmethod
+    @builtin.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -545,14 +545,14 @@ class RecursiveObjectExample(ConjureBeanType):
         # type: (Optional[RecursiveObjectAlias]) -> None
         self._recursive_field = recursive_field
 
-    @__builtin__.property
+    @builtin.property
     def recursive_field(self):
         # type: () -> Optional[RecursiveObjectAlias]
         return self._recursive_field
 
 class ReservedKeyExample(ConjureBeanType):
 
-    @__builtin__.classmethod
+    @builtin.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -574,29 +574,29 @@ class ReservedKeyExample(ConjureBeanType):
         self._field_name_with_dashes = field_name_with_dashes
         self._memoized_hash_code = memoized_hash_code
 
-    @__builtin__.property
+    @builtin.property
     def package(self):
         # type: () -> str
         return self._package
 
-    @__builtin__.property
+    @builtin.property
     def interface(self):
         # type: () -> str
         return self._interface
 
-    @__builtin__.property
+    @builtin.property
     def field_name_with_dashes(self):
         # type: () -> str
         return self._field_name_with_dashes
 
-    @__builtin__.property
+    @builtin.property
     def memoized_hash_code(self):
         # type: () -> int
         return self._memoized_hash_code
 
 class RidExample(ConjureBeanType):
 
-    @__builtin__.classmethod
+    @builtin.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -609,14 +609,14 @@ class RidExample(ConjureBeanType):
         # type: (str) -> None
         self._rid_value = rid_value
 
-    @__builtin__.property
+    @builtin.property
     def rid_value(self):
         # type: () -> str
         return self._rid_value
 
 class SafeLongExample(ConjureBeanType):
 
-    @__builtin__.classmethod
+    @builtin.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -629,14 +629,14 @@ class SafeLongExample(ConjureBeanType):
         # type: (int) -> None
         self._safe_long_value = safe_long_value
 
-    @__builtin__.property
+    @builtin.property
     def safe_long_value(self):
         # type: () -> int
         return self._safe_long_value
 
 class SetExample(ConjureBeanType):
 
-    @__builtin__.classmethod
+    @builtin.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -652,19 +652,19 @@ class SetExample(ConjureBeanType):
         self._items = items
         self._double_items = double_items
 
-    @__builtin__.property
+    @builtin.property
     def items(self):
         # type: () -> List[str]
         return self._items
 
-    @__builtin__.property
+    @builtin.property
     def double_items(self):
         # type: () -> List[float]
         return self._double_items
 
 class StringExample(ConjureBeanType):
 
-    @__builtin__.classmethod
+    @builtin.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -677,7 +677,7 @@ class StringExample(ConjureBeanType):
         # type: (str) -> None
         self._string = string
 
-    @__builtin__.property
+    @builtin.property
     def string(self):
         # type: () -> str
         return self._string
@@ -693,7 +693,7 @@ class UnionTypeExample(ConjureUnionType):
     _new = None # type: int
     _interface = None # type: int
 
-    @__builtin__.classmethod
+    @builtin.classmethod
     def _options(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -828,7 +828,7 @@ class UnionTypeExampleVisitor(ABCMeta('ABC', (object,), {})):
 
 class UuidExample(ConjureBeanType):
 
-    @__builtin__.classmethod
+    @builtin.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -841,7 +841,7 @@ class UuidExample(ConjureBeanType):
         # type: (str) -> None
         self._uuid = uuid
 
-    @__builtin__.property
+    @builtin.property
     def uuid(self):
         # type: () -> str
         return self._uuid

--- a/conjure-python-core/src/test/resources/types/expected/package_name/product_datasets/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/product_datasets/__init__.py
@@ -1,8 +1,9 @@
+import __builtin__
 from conjure_python_client import ConjureBeanType, ConjureFieldDefinition, DictType
 
 class BackingFileSystem(ConjureBeanType):
 
-    @classmethod
+    @__builtin__.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -21,25 +22,25 @@ class BackingFileSystem(ConjureBeanType):
         self._base_uri = base_uri
         self._configuration = configuration
 
-    @property
+    @__builtin__.property
     def file_system_id(self):
         # type: () -> str
         """The name by which this file system is identified."""
         return self._file_system_id
 
-    @property
+    @__builtin__.property
     def base_uri(self):
         # type: () -> str
         return self._base_uri
 
-    @property
+    @__builtin__.property
     def configuration(self):
         # type: () -> Dict[str, str]
         return self._configuration
 
 class Dataset(ConjureBeanType):
 
-    @classmethod
+    @__builtin__.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -55,12 +56,12 @@ class Dataset(ConjureBeanType):
         self._file_system_id = file_system_id
         self._rid = rid
 
-    @property
+    @__builtin__.property
     def file_system_id(self):
         # type: () -> str
         return self._file_system_id
 
-    @property
+    @__builtin__.property
     def rid(self):
         # type: () -> str
         """Uniquely identifies this dataset."""

--- a/conjure-python-core/src/test/resources/types/expected/package_name/product_datasets/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/product_datasets/__init__.py
@@ -1,9 +1,9 @@
-import builtin
+import builtins
 from conjure_python_client import ConjureBeanType, ConjureFieldDefinition, DictType
 
 class BackingFileSystem(ConjureBeanType):
 
-    @builtin.classmethod
+    @builtins.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -22,25 +22,25 @@ class BackingFileSystem(ConjureBeanType):
         self._base_uri = base_uri
         self._configuration = configuration
 
-    @builtin.property
+    @builtins.property
     def file_system_id(self):
         # type: () -> str
         """The name by which this file system is identified."""
         return self._file_system_id
 
-    @builtin.property
+    @builtins.property
     def base_uri(self):
         # type: () -> str
         return self._base_uri
 
-    @builtin.property
+    @builtins.property
     def configuration(self):
         # type: () -> Dict[str, str]
         return self._configuration
 
 class Dataset(ConjureBeanType):
 
-    @builtin.classmethod
+    @builtins.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -56,12 +56,12 @@ class Dataset(ConjureBeanType):
         self._file_system_id = file_system_id
         self._rid = rid
 
-    @builtin.property
+    @builtins.property
     def file_system_id(self):
         # type: () -> str
         return self._file_system_id
 
-    @builtin.property
+    @builtins.property
     def rid(self):
         # type: () -> str
         """Uniquely identifies this dataset."""

--- a/conjure-python-core/src/test/resources/types/expected/package_name/product_datasets/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/product_datasets/__init__.py
@@ -1,9 +1,9 @@
-import __builtin__
+import builtin
 from conjure_python_client import ConjureBeanType, ConjureFieldDefinition, DictType
 
 class BackingFileSystem(ConjureBeanType):
 
-    @__builtin__.classmethod
+    @builtin.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -22,25 +22,25 @@ class BackingFileSystem(ConjureBeanType):
         self._base_uri = base_uri
         self._configuration = configuration
 
-    @__builtin__.property
+    @builtin.property
     def file_system_id(self):
         # type: () -> str
         """The name by which this file system is identified."""
         return self._file_system_id
 
-    @__builtin__.property
+    @builtin.property
     def base_uri(self):
         # type: () -> str
         return self._base_uri
 
-    @__builtin__.property
+    @builtin.property
     def configuration(self):
         # type: () -> Dict[str, str]
         return self._configuration
 
 class Dataset(ConjureBeanType):
 
-    @__builtin__.classmethod
+    @builtin.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -56,12 +56,12 @@ class Dataset(ConjureBeanType):
         self._file_system_id = file_system_id
         self._rid = rid
 
-    @__builtin__.property
+    @builtin.property
     def file_system_id(self):
         # type: () -> str
         return self._file_system_id
 
-    @__builtin__.property
+    @builtin.property
     def rid(self):
         # type: () -> str
         """Uniquely identifies this dataset."""

--- a/conjure-python-core/src/test/resources/types/expected/package_name/with_imports/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/with_imports/__init__.py
@@ -1,12 +1,12 @@
 from ..product import AnyMapExample, DateTimeAliasExample, ManyFieldExample, ReferenceAliasExample, RidAliasExample, StringAliasExample, StringExample
 from ..product_datasets import BackingFileSystem
-import __builtin__
 from abc import ABCMeta, abstractmethod
+import builtin
 from conjure_python_client import ConjureBeanType, ConjureDecoder, ConjureEncoder, ConjureFieldDefinition, ConjureUnionType, DictType, Service
 
 class ComplexObjectWithImports(ConjureBeanType):
 
-    @__builtin__.classmethod
+    @builtin.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -22,12 +22,12 @@ class ComplexObjectWithImports(ConjureBeanType):
         self._string = string
         self._imported = imported
 
-    @__builtin__.property
+    @builtin.property
     def string(self):
         # type: () -> str
         return self._string
 
-    @__builtin__.property
+    @builtin.property
     def imported(self):
         # type: () -> StringExample
         return self._imported
@@ -65,7 +65,7 @@ class ImportService(Service):
 
 class ImportedAliasInMaps(ConjureBeanType):
 
-    @__builtin__.classmethod
+    @builtin.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -78,7 +78,7 @@ class ImportedAliasInMaps(ConjureBeanType):
         # type: (Dict[RidAliasExample, DateTimeAliasExample]) -> None
         self._aliases = aliases
 
-    @__builtin__.property
+    @builtin.property
     def aliases(self):
         # type: () -> Dict[RidAliasExample, DateTimeAliasExample]
         return self._aliases
@@ -88,7 +88,7 @@ class UnionWithImports(ConjureUnionType):
     _string = None # type: str
     _imported = None # type: AnyMapExample
 
-    @__builtin__.classmethod
+    @builtin.classmethod
     def _options(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {

--- a/conjure-python-core/src/test/resources/types/expected/package_name/with_imports/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/with_imports/__init__.py
@@ -1,12 +1,12 @@
 from ..product import AnyMapExample, DateTimeAliasExample, ManyFieldExample, ReferenceAliasExample, RidAliasExample, StringAliasExample, StringExample
 from ..product_datasets import BackingFileSystem
 from abc import ABCMeta, abstractmethod
-import builtin
+import builtins
 from conjure_python_client import ConjureBeanType, ConjureDecoder, ConjureEncoder, ConjureFieldDefinition, ConjureUnionType, DictType, Service
 
 class ComplexObjectWithImports(ConjureBeanType):
 
-    @builtin.classmethod
+    @builtins.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -22,12 +22,12 @@ class ComplexObjectWithImports(ConjureBeanType):
         self._string = string
         self._imported = imported
 
-    @builtin.property
+    @builtins.property
     def string(self):
         # type: () -> str
         return self._string
 
-    @builtin.property
+    @builtins.property
     def imported(self):
         # type: () -> StringExample
         return self._imported
@@ -65,7 +65,7 @@ class ImportService(Service):
 
 class ImportedAliasInMaps(ConjureBeanType):
 
-    @builtin.classmethod
+    @builtins.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -78,7 +78,7 @@ class ImportedAliasInMaps(ConjureBeanType):
         # type: (Dict[RidAliasExample, DateTimeAliasExample]) -> None
         self._aliases = aliases
 
-    @builtin.property
+    @builtins.property
     def aliases(self):
         # type: () -> Dict[RidAliasExample, DateTimeAliasExample]
         return self._aliases
@@ -88,7 +88,7 @@ class UnionWithImports(ConjureUnionType):
     _string = None # type: str
     _imported = None # type: AnyMapExample
 
-    @builtin.classmethod
+    @builtins.classmethod
     def _options(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {

--- a/conjure-python-core/src/test/resources/types/expected/package_name/with_imports/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/with_imports/__init__.py
@@ -1,11 +1,12 @@
 from ..product import AnyMapExample, DateTimeAliasExample, ManyFieldExample, ReferenceAliasExample, RidAliasExample, StringAliasExample, StringExample
 from ..product_datasets import BackingFileSystem
+import __builtin__
 from abc import ABCMeta, abstractmethod
 from conjure_python_client import ConjureBeanType, ConjureDecoder, ConjureEncoder, ConjureFieldDefinition, ConjureUnionType, DictType, Service
 
 class ComplexObjectWithImports(ConjureBeanType):
 
-    @classmethod
+    @__builtin__.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -21,12 +22,12 @@ class ComplexObjectWithImports(ConjureBeanType):
         self._string = string
         self._imported = imported
 
-    @property
+    @__builtin__.property
     def string(self):
         # type: () -> str
         return self._string
 
-    @property
+    @__builtin__.property
     def imported(self):
         # type: () -> StringExample
         return self._imported
@@ -64,7 +65,7 @@ class ImportService(Service):
 
 class ImportedAliasInMaps(ConjureBeanType):
 
-    @classmethod
+    @__builtin__.classmethod
     def _fields(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
@@ -77,7 +78,7 @@ class ImportedAliasInMaps(ConjureBeanType):
         # type: (Dict[RidAliasExample, DateTimeAliasExample]) -> None
         self._aliases = aliases
 
-    @property
+    @__builtin__.property
     def aliases(self):
         # type: () -> Dict[RidAliasExample, DateTimeAliasExample]
         return self._aliases
@@ -87,7 +88,7 @@ class UnionWithImports(ConjureUnionType):
     _string = None # type: str
     _imported = None # type: AnyMapExample
 
-    @classmethod
+    @__builtin__.classmethod
     def _options(cls):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {

--- a/conjure-python-core/src/test/resources/types/expected/setup.py
+++ b/conjure-python-core/src/test/resources/types/expected/setup.py
@@ -9,5 +9,6 @@ setup(
         'requests',
         'typing',
         'conjure-python-client>=1.0.0,<2',
+        'future',
     ],
 )

--- a/conjure-python-verifier/python/setup.py
+++ b/conjure-python-verifier/python/setup.py
@@ -33,7 +33,8 @@ setup(
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
         "conjure-python-client=={}".format(os.environ.get('CONJURE_PYTHON_CLIENT_VERSION')),
-        "pyyaml"
+        "pyyaml",
+        "future"
     ],
     tests_require=["pytest", "pyyaml"],
 )


### PR DESCRIPTION
Closes #70 #74

## Before this PR
methods that collided with built-ins (property, classmethod) would cause errors at run-time

## After this PR
We defensively import `__built__` and reference built-ins through it to prevent collisions 
