### PR TITLE
[improvement] add slots to beans

### DIFF
--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/BeanSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/BeanSnippet.java
@@ -80,7 +80,7 @@ public interface BeanSnippet extends PythonSnippet {
         poetWriter.writeLine();
 
         poetWriter.writeIndentedLine(String.format("__slots__ = [%s]", fields().stream()
-                .map(field -> String.format("'%s'", PythonIdentifierSanitizer.sanitize(field.attributeName())))
+                .map(field -> String.format("'_%s'", PythonIdentifierSanitizer.sanitize(field.attributeName())))
                 .collect(Collectors.joining(", "))));
 
         poetWriter.writeLine();

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/BeanSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/BeanSnippet.java
@@ -79,6 +79,12 @@ public interface BeanSnippet extends PythonSnippet {
 
         poetWriter.writeLine();
 
+        poetWriter.writeIndentedLine(String.format("__slots__ = [%s]", fields().stream()
+                .map(field -> String.format("'%s'", PythonIdentifierSanitizer.sanitize(field.attributeName())))
+                .collect(Collectors.joining(", "))));
+
+        poetWriter.writeLine();
+
         // constructor -- only if there are fields
         if (!fields().isEmpty()) {
             poetWriter.writeIndentedLine(String.format("def __init__(self, %s):",

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/BeanSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/BeanSnippet.java
@@ -72,13 +72,6 @@ public interface BeanSnippet extends PythonSnippet {
 
         poetWriter.writeLine();
 
-        // entry for each field
-        fields().forEach(field -> poetWriter.writeIndentedLine(String.format("_%s = None # type: %s",
-                field.attributeName(),
-                field.myPyType())));
-
-        poetWriter.writeLine();
-
         poetWriter.writeIndentedLine(String.format("__slots__ = [%s]", fields().stream()
                 .map(field -> String.format("'_%s'", PythonIdentifierSanitizer.sanitize(field.attributeName())))
                 .collect(Collectors.joining(", "))));

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
@@ -83,12 +83,6 @@ public interface UnionSnippet extends PythonSnippet {
 
         poetWriter.writeLine();
 
-        poetWriter.writeIndentedLine(String.format("__slots__ = [%s]", options().stream()
-                .map(field -> String.format("'_%s'", PythonIdentifierSanitizer.sanitize(field.attributeName())))
-                .collect(Collectors.joining(", "))));
-
-        poetWriter.writeLine();
-
         // constructor
         poetWriter.writeIndentedLine(String.format("def __init__(self, %s):",
                 Joiner.on(", ").join(

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
@@ -84,7 +84,7 @@ public interface UnionSnippet extends PythonSnippet {
         poetWriter.writeLine();
 
         poetWriter.writeIndentedLine(String.format("__slots__ = [%s]", options().stream()
-                .map(field -> String.format("'%s'", PythonIdentifierSanitizer.sanitize(field.attributeName())))
+                .map(field -> String.format("'_%s'", PythonIdentifierSanitizer.sanitize(field.attributeName())))
                 .collect(Collectors.joining(", "))));
 
         poetWriter.writeLine();

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
@@ -83,6 +83,12 @@ public interface UnionSnippet extends PythonSnippet {
 
         poetWriter.writeLine();
 
+        poetWriter.writeIndentedLine(String.format("__slots__ = [%s]", options().stream()
+                .map(field -> String.format("'%s'", PythonIdentifierSanitizer.sanitize(field.attributeName())))
+                .collect(Collectors.joining(", "))));
+
+        poetWriter.writeLine();
+
         // constructor
         poetWriter.writeIndentedLine(String.format("def __init__(self, %s):",
                 Joiner.on(", ").join(

--- a/conjure-python-core/src/test/resources/services/expected/package_name/product/__init__.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/product/__init__.py
@@ -13,6 +13,8 @@ class CreateDatasetRequest(ConjureBeanType):
     _file_system_id = None # type: str
     _path = None # type: str
 
+    __slots__ = ['file_system_id', 'path']
+
     def __init__(self, file_system_id, path):
         # type: (str, str) -> None
         self._file_system_id = file_system_id

--- a/conjure-python-core/src/test/resources/services/expected/package_name/product/__init__.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/product/__init__.py
@@ -10,9 +10,6 @@ class CreateDatasetRequest(ConjureBeanType):
             'path': ConjureFieldDefinition('path', str)
         }
 
-    _file_system_id = None # type: str
-    _path = None # type: str
-
     __slots__ = ['_file_system_id', '_path']
 
     def __init__(self, file_system_id, path):

--- a/conjure-python-core/src/test/resources/services/expected/package_name/product/__init__.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/product/__init__.py
@@ -13,7 +13,7 @@ class CreateDatasetRequest(ConjureBeanType):
     _file_system_id = None # type: str
     _path = None # type: str
 
-    __slots__ = ['file_system_id', 'path']
+    __slots__ = ['_file_system_id', '_path']
 
     def __init__(self, file_system_id, path):
         # type: (str, str) -> None

--- a/conjure-python-core/src/test/resources/services/expected/package_name/product_datasets/__init__.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/product_datasets/__init__.py
@@ -15,6 +15,8 @@ class BackingFileSystem(ConjureBeanType):
     _base_uri = None # type: str
     _configuration = None # type: Dict[str, str]
 
+    __slots__ = ['file_system_id', 'base_uri', 'configuration']
+
     def __init__(self, base_uri, configuration, file_system_id):
         # type: (str, Dict[str, str], str) -> None
         self._file_system_id = file_system_id
@@ -49,6 +51,8 @@ class Dataset(ConjureBeanType):
 
     _file_system_id = None # type: str
     _rid = None # type: str
+
+    __slots__ = ['file_system_id', 'rid']
 
     def __init__(self, file_system_id, rid):
         # type: (str, str) -> None

--- a/conjure-python-core/src/test/resources/services/expected/package_name/product_datasets/__init__.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/product_datasets/__init__.py
@@ -15,7 +15,7 @@ class BackingFileSystem(ConjureBeanType):
     _base_uri = None # type: str
     _configuration = None # type: Dict[str, str]
 
-    __slots__ = ['file_system_id', 'base_uri', 'configuration']
+    __slots__ = ['_file_system_id', '_base_uri', '_configuration']
 
     def __init__(self, base_uri, configuration, file_system_id):
         # type: (str, Dict[str, str], str) -> None
@@ -52,7 +52,7 @@ class Dataset(ConjureBeanType):
     _file_system_id = None # type: str
     _rid = None # type: str
 
-    __slots__ = ['file_system_id', 'rid']
+    __slots__ = ['_file_system_id', '_rid']
 
     def __init__(self, file_system_id, rid):
         # type: (str, str) -> None

--- a/conjure-python-core/src/test/resources/services/expected/package_name/product_datasets/__init__.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/product_datasets/__init__.py
@@ -11,10 +11,6 @@ class BackingFileSystem(ConjureBeanType):
             'configuration': ConjureFieldDefinition('configuration', DictType(str, str))
         }
 
-    _file_system_id = None # type: str
-    _base_uri = None # type: str
-    _configuration = None # type: Dict[str, str]
-
     __slots__ = ['_file_system_id', '_base_uri', '_configuration']
 
     def __init__(self, base_uri, configuration, file_system_id):
@@ -48,9 +44,6 @@ class Dataset(ConjureBeanType):
             'file_system_id': ConjureFieldDefinition('fileSystemId', str),
             'rid': ConjureFieldDefinition('rid', str)
         }
-
-    _file_system_id = None # type: str
-    _rid = None # type: str
 
     __slots__ = ['_file_system_id', '_rid']
 

--- a/conjure-python-core/src/test/resources/types/expected/package_name/nested_service/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/nested_service/__init__.py
@@ -42,7 +42,7 @@ class SimpleObject(ConjureBeanType):
 
     _string = None # type: str
 
-    __slots__ = ['string']
+    __slots__ = ['_string']
 
     def __init__(self, string):
         # type: (str) -> None

--- a/conjure-python-core/src/test/resources/types/expected/package_name/nested_service/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/nested_service/__init__.py
@@ -42,6 +42,8 @@ class SimpleObject(ConjureBeanType):
 
     _string = None # type: str
 
+    __slots__ = ['string']
+
     def __init__(self, string):
         # type: (str) -> None
         self._string = string

--- a/conjure-python-core/src/test/resources/types/expected/package_name/nested_service/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/nested_service/__init__.py
@@ -40,8 +40,6 @@ class SimpleObject(ConjureBeanType):
             'string': ConjureFieldDefinition('string', str)
         }
 
-    _string = None # type: str
-
     __slots__ = ['_string']
 
     def __init__(self, string):

--- a/conjure-python-core/src/test/resources/types/expected/package_name/product/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/product/__init__.py
@@ -25,6 +25,8 @@ class AliasAsMapKeyExample(ConjureBeanType):
     _datetimes = None # type: Dict[DateTimeAliasExample, ManyFieldExample]
     _uuids = None # type: Dict[UuidAliasExample, ManyFieldExample]
 
+    __slots__ = ['strings', 'rids', 'bearertokens', 'integers', 'safelongs', 'datetimes', 'uuids']
+
     def __init__(self, bearertokens, datetimes, integers, rids, safelongs, strings, uuids):
         # type: (Dict[BearerTokenAliasExample, ManyFieldExample], Dict[DateTimeAliasExample, ManyFieldExample], Dict[IntegerAliasExample, ManyFieldExample], Dict[RidAliasExample, ManyFieldExample], Dict[SafeLongAliasExample, ManyFieldExample], Dict[StringAliasExample, ManyFieldExample], Dict[UuidAliasExample, ManyFieldExample]) -> None
         self._strings = strings
@@ -81,6 +83,8 @@ class AnyExample(ConjureBeanType):
 
     _any = None # type: Any
 
+    __slots__ = ['any']
+
     def __init__(self, any):
         # type: (Any) -> None
         self._any = any
@@ -100,6 +104,8 @@ class AnyMapExample(ConjureBeanType):
         }
 
     _items = None # type: Dict[str, Any]
+
+    __slots__ = ['items']
 
     def __init__(self, items):
         # type: (Dict[str, Any]) -> None
@@ -121,6 +127,8 @@ class BearerTokenExample(ConjureBeanType):
 
     _bearer_token_value = None # type: str
 
+    __slots__ = ['bearer_token_value']
+
     def __init__(self, bearer_token_value):
         # type: (str) -> None
         self._bearer_token_value = bearer_token_value
@@ -141,6 +149,8 @@ class BinaryExample(ConjureBeanType):
 
     _binary = None # type: Any
 
+    __slots__ = ['binary']
+
     def __init__(self, binary):
         # type: (Any) -> None
         self._binary = binary
@@ -160,6 +170,8 @@ class BooleanExample(ConjureBeanType):
         }
 
     _coin = None # type: bool
+
+    __slots__ = ['coin']
 
     def __init__(self, coin):
         # type: (bool) -> None
@@ -182,6 +194,8 @@ class CreateDatasetRequest(ConjureBeanType):
 
     _file_system_id = None # type: str
     _path = None # type: str
+
+    __slots__ = ['file_system_id', 'path']
 
     def __init__(self, file_system_id, path):
         # type: (str, str) -> None
@@ -209,6 +223,8 @@ class DateTimeExample(ConjureBeanType):
 
     _datetime = None # type: str
 
+    __slots__ = ['datetime']
+
     def __init__(self, datetime):
         # type: (str) -> None
         self._datetime = datetime
@@ -229,6 +245,8 @@ class DoubleExample(ConjureBeanType):
 
     _double_value = None # type: float
 
+    __slots__ = ['double_value']
+
     def __init__(self, double_value):
         # type: (float) -> None
         self._double_value = double_value
@@ -246,6 +264,8 @@ class EmptyObjectExample(ConjureBeanType):
         return {
         }
 
+
+    __slots__ = []
 
 
 class EnumExample(ConjureEnumType):
@@ -272,6 +292,8 @@ class EnumFieldExample(ConjureBeanType):
 
     _enum = None # type: EnumExample
 
+    __slots__ = ['enum']
+
     def __init__(self, enum):
         # type: (EnumExample) -> None
         self._enum = enum
@@ -291,6 +313,8 @@ class IntegerExample(ConjureBeanType):
         }
 
     _integer = None # type: int
+
+    __slots__ = ['integer']
 
     def __init__(self, integer):
         # type: (int) -> None
@@ -315,6 +339,8 @@ class ListExample(ConjureBeanType):
     _items = None # type: List[str]
     _primitive_items = None # type: List[int]
     _double_items = None # type: List[float]
+
+    __slots__ = ['items', 'primitive_items', 'double_items']
 
     def __init__(self, double_items, items, primitive_items):
         # type: (List[float], List[str], List[int]) -> None
@@ -361,6 +387,8 @@ class ManyFieldExample(ConjureBeanType):
     _set = None # type: List[str]
     _map = None # type: Dict[str, str]
     _alias = None # type: StringAliasExample
+
+    __slots__ = ['string', 'integer', 'double_value', 'optional_item', 'items', 'set', 'map', 'alias']
 
     def __init__(self, alias, double_value, integer, items, map, set, string, optional_item=None):
         # type: (StringAliasExample, float, int, List[str], Dict[str, str], List[str], str, Optional[str]) -> None
@@ -432,6 +460,8 @@ class MapExample(ConjureBeanType):
 
     _items = None # type: Dict[str, str]
 
+    __slots__ = ['items']
+
     def __init__(self, items):
         # type: (Dict[str, str]) -> None
         self._items = items
@@ -451,6 +481,8 @@ class OptionalExample(ConjureBeanType):
         }
 
     _item = None # type: Optional[str]
+
+    __slots__ = ['item']
 
     def __init__(self, item=None):
         # type: (Optional[str]) -> None
@@ -483,6 +515,8 @@ class PrimitiveOptionalsExample(ConjureBeanType):
     _rid = None # type: Optional[str]
     _bearertoken = None # type: Optional[str]
     _uuid = None # type: Optional[str]
+
+    __slots__ = ['num', 'bool', 'integer', 'safelong', 'rid', 'bearertoken', 'uuid']
 
     def __init__(self, bearertoken=None, bool=None, integer=None, num=None, rid=None, safelong=None, uuid=None):
         # type: (Optional[str], Optional[bool], Optional[int], Optional[float], Optional[str], Optional[int], Optional[str]) -> None
@@ -540,6 +574,8 @@ class RecursiveObjectExample(ConjureBeanType):
 
     _recursive_field = None # type: Optional[RecursiveObjectAlias]
 
+    __slots__ = ['recursive_field']
+
     def __init__(self, recursive_field=None):
         # type: (Optional[RecursiveObjectAlias]) -> None
         self._recursive_field = recursive_field
@@ -565,6 +601,8 @@ class ReservedKeyExample(ConjureBeanType):
     _interface = None # type: str
     _field_name_with_dashes = None # type: str
     _memoized_hash_code = None # type: int
+
+    __slots__ = ['package', 'interface', 'field_name_with_dashes', 'memoized_hash_code']
 
     def __init__(self, field_name_with_dashes, interface, memoized_hash_code, package):
         # type: (str, str, int, str) -> None
@@ -604,6 +642,8 @@ class RidExample(ConjureBeanType):
 
     _rid_value = None # type: str
 
+    __slots__ = ['rid_value']
+
     def __init__(self, rid_value):
         # type: (str) -> None
         self._rid_value = rid_value
@@ -623,6 +663,8 @@ class SafeLongExample(ConjureBeanType):
         }
 
     _safe_long_value = None # type: int
+
+    __slots__ = ['safe_long_value']
 
     def __init__(self, safe_long_value):
         # type: (int) -> None
@@ -645,6 +687,8 @@ class SetExample(ConjureBeanType):
 
     _items = None # type: List[str]
     _double_items = None # type: List[float]
+
+    __slots__ = ['items', 'double_items']
 
     def __init__(self, double_items, items):
         # type: (List[float], List[str]) -> None
@@ -671,6 +715,8 @@ class StringExample(ConjureBeanType):
         }
 
     _string = None # type: str
+
+    __slots__ = ['string']
 
     def __init__(self, string):
         # type: (str) -> None
@@ -704,6 +750,8 @@ class UnionTypeExample(ConjureUnionType):
             'new': ConjureFieldDefinition('new', int),
             'interface': ConjureFieldDefinition('interface', int)
         }
+
+    __slots__ = ['string_example', 'set', 'this_field_is_an_integer', 'also_an_integer', 'if_', 'new', 'interface']
 
     def __init__(self, string_example=None, set=None, this_field_is_an_integer=None, also_an_integer=None, if_=None, new=None, interface=None):
         if (string_example is not None) + (set is not None) + (this_field_is_an_integer is not None) + (also_an_integer is not None) + (if_ is not None) + (new is not None) + (interface is not None) != 1:
@@ -835,6 +883,8 @@ class UuidExample(ConjureBeanType):
         }
 
     _uuid = None # type: str
+
+    __slots__ = ['uuid']
 
     def __init__(self, uuid):
         # type: (str) -> None

--- a/conjure-python-core/src/test/resources/types/expected/package_name/product/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/product/__init__.py
@@ -17,14 +17,6 @@ class AliasAsMapKeyExample(ConjureBeanType):
             'uuids': ConjureFieldDefinition('uuids', DictType(UuidAliasExample, ManyFieldExample))
         }
 
-    _strings = None # type: Dict[StringAliasExample, ManyFieldExample]
-    _rids = None # type: Dict[RidAliasExample, ManyFieldExample]
-    _bearertokens = None # type: Dict[BearerTokenAliasExample, ManyFieldExample]
-    _integers = None # type: Dict[IntegerAliasExample, ManyFieldExample]
-    _safelongs = None # type: Dict[SafeLongAliasExample, ManyFieldExample]
-    _datetimes = None # type: Dict[DateTimeAliasExample, ManyFieldExample]
-    _uuids = None # type: Dict[UuidAliasExample, ManyFieldExample]
-
     __slots__ = ['_strings', '_rids', '_bearertokens', '_integers', '_safelongs', '_datetimes', '_uuids']
 
     def __init__(self, bearertokens, datetimes, integers, rids, safelongs, strings, uuids):
@@ -81,8 +73,6 @@ class AnyExample(ConjureBeanType):
             'any': ConjureFieldDefinition('any', object)
         }
 
-    _any = None # type: Any
-
     __slots__ = ['_any']
 
     def __init__(self, any):
@@ -102,8 +92,6 @@ class AnyMapExample(ConjureBeanType):
         return {
             'items': ConjureFieldDefinition('items', DictType(str, object))
         }
-
-    _items = None # type: Dict[str, Any]
 
     __slots__ = ['_items']
 
@@ -125,8 +113,6 @@ class BearerTokenExample(ConjureBeanType):
             'bearer_token_value': ConjureFieldDefinition('bearerTokenValue', str)
         }
 
-    _bearer_token_value = None # type: str
-
     __slots__ = ['_bearer_token_value']
 
     def __init__(self, bearer_token_value):
@@ -146,8 +132,6 @@ class BinaryExample(ConjureBeanType):
         return {
             'binary': ConjureFieldDefinition('binary', BinaryType())
         }
-
-    _binary = None # type: Any
 
     __slots__ = ['_binary']
 
@@ -169,8 +153,6 @@ class BooleanExample(ConjureBeanType):
             'coin': ConjureFieldDefinition('coin', bool)
         }
 
-    _coin = None # type: bool
-
     __slots__ = ['_coin']
 
     def __init__(self, coin):
@@ -191,9 +173,6 @@ class CreateDatasetRequest(ConjureBeanType):
             'file_system_id': ConjureFieldDefinition('fileSystemId', str),
             'path': ConjureFieldDefinition('path', str)
         }
-
-    _file_system_id = None # type: str
-    _path = None # type: str
 
     __slots__ = ['_file_system_id', '_path']
 
@@ -221,8 +200,6 @@ class DateTimeExample(ConjureBeanType):
             'datetime': ConjureFieldDefinition('datetime', str)
         }
 
-    _datetime = None # type: str
-
     __slots__ = ['_datetime']
 
     def __init__(self, datetime):
@@ -243,8 +220,6 @@ class DoubleExample(ConjureBeanType):
             'double_value': ConjureFieldDefinition('doubleValue', float)
         }
 
-    _double_value = None # type: float
-
     __slots__ = ['_double_value']
 
     def __init__(self, double_value):
@@ -263,7 +238,6 @@ class EmptyObjectExample(ConjureBeanType):
         # type: () -> Dict[str, ConjureFieldDefinition]
         return {
         }
-
 
     __slots__ = []
 
@@ -290,8 +264,6 @@ class EnumFieldExample(ConjureBeanType):
             'enum': ConjureFieldDefinition('enum', EnumExample)
         }
 
-    _enum = None # type: EnumExample
-
     __slots__ = ['_enum']
 
     def __init__(self, enum):
@@ -311,8 +283,6 @@ class IntegerExample(ConjureBeanType):
         return {
             'integer': ConjureFieldDefinition('integer', int)
         }
-
-    _integer = None # type: int
 
     __slots__ = ['_integer']
 
@@ -335,10 +305,6 @@ class ListExample(ConjureBeanType):
             'primitive_items': ConjureFieldDefinition('primitiveItems', ListType(int)),
             'double_items': ConjureFieldDefinition('doubleItems', ListType(float))
         }
-
-    _items = None # type: List[str]
-    _primitive_items = None # type: List[int]
-    _double_items = None # type: List[float]
 
     __slots__ = ['_items', '_primitive_items', '_double_items']
 
@@ -378,15 +344,6 @@ class ManyFieldExample(ConjureBeanType):
             'map': ConjureFieldDefinition('map', DictType(str, str)),
             'alias': ConjureFieldDefinition('alias', StringAliasExample)
         }
-
-    _string = None # type: str
-    _integer = None # type: int
-    _double_value = None # type: float
-    _optional_item = None # type: Optional[str]
-    _items = None # type: List[str]
-    _set = None # type: List[str]
-    _map = None # type: Dict[str, str]
-    _alias = None # type: StringAliasExample
 
     __slots__ = ['_string', '_integer', '_double_value', '_optional_item', '_items', '_set', '_map', '_alias']
 
@@ -458,8 +415,6 @@ class MapExample(ConjureBeanType):
             'items': ConjureFieldDefinition('items', DictType(str, str))
         }
 
-    _items = None # type: Dict[str, str]
-
     __slots__ = ['_items']
 
     def __init__(self, items):
@@ -479,8 +434,6 @@ class OptionalExample(ConjureBeanType):
         return {
             'item': ConjureFieldDefinition('item', OptionalType(str))
         }
-
-    _item = None # type: Optional[str]
 
     __slots__ = ['_item']
 
@@ -507,14 +460,6 @@ class PrimitiveOptionalsExample(ConjureBeanType):
             'bearertoken': ConjureFieldDefinition('bearertoken', OptionalType(str)),
             'uuid': ConjureFieldDefinition('uuid', OptionalType(str))
         }
-
-    _num = None # type: Optional[float]
-    _bool = None # type: Optional[bool]
-    _integer = None # type: Optional[int]
-    _safelong = None # type: Optional[int]
-    _rid = None # type: Optional[str]
-    _bearertoken = None # type: Optional[str]
-    _uuid = None # type: Optional[str]
 
     __slots__ = ['_num', '_bool', '_integer', '_safelong', '_rid', '_bearertoken', '_uuid']
 
@@ -572,8 +517,6 @@ class RecursiveObjectExample(ConjureBeanType):
             'recursive_field': ConjureFieldDefinition('recursiveField', OptionalType(RecursiveObjectAlias))
         }
 
-    _recursive_field = None # type: Optional[RecursiveObjectAlias]
-
     __slots__ = ['_recursive_field']
 
     def __init__(self, recursive_field=None):
@@ -596,11 +539,6 @@ class ReservedKeyExample(ConjureBeanType):
             'field_name_with_dashes': ConjureFieldDefinition('field-name-with-dashes', str),
             'memoized_hash_code': ConjureFieldDefinition('memoizedHashCode', int)
         }
-
-    _package = None # type: str
-    _interface = None # type: str
-    _field_name_with_dashes = None # type: str
-    _memoized_hash_code = None # type: int
 
     __slots__ = ['_package', '_interface', '_field_name_with_dashes', '_memoized_hash_code']
 
@@ -640,8 +578,6 @@ class RidExample(ConjureBeanType):
             'rid_value': ConjureFieldDefinition('ridValue', str)
         }
 
-    _rid_value = None # type: str
-
     __slots__ = ['_rid_value']
 
     def __init__(self, rid_value):
@@ -661,8 +597,6 @@ class SafeLongExample(ConjureBeanType):
         return {
             'safe_long_value': ConjureFieldDefinition('safeLongValue', int)
         }
-
-    _safe_long_value = None # type: int
 
     __slots__ = ['_safe_long_value']
 
@@ -684,9 +618,6 @@ class SetExample(ConjureBeanType):
             'items': ConjureFieldDefinition('items', ListType(str)),
             'double_items': ConjureFieldDefinition('doubleItems', ListType(float))
         }
-
-    _items = None # type: List[str]
-    _double_items = None # type: List[float]
 
     __slots__ = ['_items', '_double_items']
 
@@ -713,8 +644,6 @@ class StringExample(ConjureBeanType):
         return {
             'string': ConjureFieldDefinition('string', str)
         }
-
-    _string = None # type: str
 
     __slots__ = ['_string']
 
@@ -881,8 +810,6 @@ class UuidExample(ConjureBeanType):
         return {
             'uuid': ConjureFieldDefinition('uuid', str)
         }
-
-    _uuid = None # type: str
 
     __slots__ = ['_uuid']
 

--- a/conjure-python-core/src/test/resources/types/expected/package_name/product/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/product/__init__.py
@@ -25,7 +25,7 @@ class AliasAsMapKeyExample(ConjureBeanType):
     _datetimes = None # type: Dict[DateTimeAliasExample, ManyFieldExample]
     _uuids = None # type: Dict[UuidAliasExample, ManyFieldExample]
 
-    __slots__ = ['strings', 'rids', 'bearertokens', 'integers', 'safelongs', 'datetimes', 'uuids']
+    __slots__ = ['_strings', '_rids', '_bearertokens', '_integers', '_safelongs', '_datetimes', '_uuids']
 
     def __init__(self, bearertokens, datetimes, integers, rids, safelongs, strings, uuids):
         # type: (Dict[BearerTokenAliasExample, ManyFieldExample], Dict[DateTimeAliasExample, ManyFieldExample], Dict[IntegerAliasExample, ManyFieldExample], Dict[RidAliasExample, ManyFieldExample], Dict[SafeLongAliasExample, ManyFieldExample], Dict[StringAliasExample, ManyFieldExample], Dict[UuidAliasExample, ManyFieldExample]) -> None
@@ -83,7 +83,7 @@ class AnyExample(ConjureBeanType):
 
     _any = None # type: Any
 
-    __slots__ = ['any']
+    __slots__ = ['_any']
 
     def __init__(self, any):
         # type: (Any) -> None
@@ -105,7 +105,7 @@ class AnyMapExample(ConjureBeanType):
 
     _items = None # type: Dict[str, Any]
 
-    __slots__ = ['items']
+    __slots__ = ['_items']
 
     def __init__(self, items):
         # type: (Dict[str, Any]) -> None
@@ -127,7 +127,7 @@ class BearerTokenExample(ConjureBeanType):
 
     _bearer_token_value = None # type: str
 
-    __slots__ = ['bearer_token_value']
+    __slots__ = ['_bearer_token_value']
 
     def __init__(self, bearer_token_value):
         # type: (str) -> None
@@ -149,7 +149,7 @@ class BinaryExample(ConjureBeanType):
 
     _binary = None # type: Any
 
-    __slots__ = ['binary']
+    __slots__ = ['_binary']
 
     def __init__(self, binary):
         # type: (Any) -> None
@@ -171,7 +171,7 @@ class BooleanExample(ConjureBeanType):
 
     _coin = None # type: bool
 
-    __slots__ = ['coin']
+    __slots__ = ['_coin']
 
     def __init__(self, coin):
         # type: (bool) -> None
@@ -195,7 +195,7 @@ class CreateDatasetRequest(ConjureBeanType):
     _file_system_id = None # type: str
     _path = None # type: str
 
-    __slots__ = ['file_system_id', 'path']
+    __slots__ = ['_file_system_id', '_path']
 
     def __init__(self, file_system_id, path):
         # type: (str, str) -> None
@@ -223,7 +223,7 @@ class DateTimeExample(ConjureBeanType):
 
     _datetime = None # type: str
 
-    __slots__ = ['datetime']
+    __slots__ = ['_datetime']
 
     def __init__(self, datetime):
         # type: (str) -> None
@@ -245,7 +245,7 @@ class DoubleExample(ConjureBeanType):
 
     _double_value = None # type: float
 
-    __slots__ = ['double_value']
+    __slots__ = ['_double_value']
 
     def __init__(self, double_value):
         # type: (float) -> None
@@ -292,7 +292,7 @@ class EnumFieldExample(ConjureBeanType):
 
     _enum = None # type: EnumExample
 
-    __slots__ = ['enum']
+    __slots__ = ['_enum']
 
     def __init__(self, enum):
         # type: (EnumExample) -> None
@@ -314,7 +314,7 @@ class IntegerExample(ConjureBeanType):
 
     _integer = None # type: int
 
-    __slots__ = ['integer']
+    __slots__ = ['_integer']
 
     def __init__(self, integer):
         # type: (int) -> None
@@ -340,7 +340,7 @@ class ListExample(ConjureBeanType):
     _primitive_items = None # type: List[int]
     _double_items = None # type: List[float]
 
-    __slots__ = ['items', 'primitive_items', 'double_items']
+    __slots__ = ['_items', '_primitive_items', '_double_items']
 
     def __init__(self, double_items, items, primitive_items):
         # type: (List[float], List[str], List[int]) -> None
@@ -388,7 +388,7 @@ class ManyFieldExample(ConjureBeanType):
     _map = None # type: Dict[str, str]
     _alias = None # type: StringAliasExample
 
-    __slots__ = ['string', 'integer', 'double_value', 'optional_item', 'items', 'set', 'map', 'alias']
+    __slots__ = ['_string', '_integer', '_double_value', '_optional_item', '_items', '_set', '_map', '_alias']
 
     def __init__(self, alias, double_value, integer, items, map, set, string, optional_item=None):
         # type: (StringAliasExample, float, int, List[str], Dict[str, str], List[str], str, Optional[str]) -> None
@@ -460,7 +460,7 @@ class MapExample(ConjureBeanType):
 
     _items = None # type: Dict[str, str]
 
-    __slots__ = ['items']
+    __slots__ = ['_items']
 
     def __init__(self, items):
         # type: (Dict[str, str]) -> None
@@ -482,7 +482,7 @@ class OptionalExample(ConjureBeanType):
 
     _item = None # type: Optional[str]
 
-    __slots__ = ['item']
+    __slots__ = ['_item']
 
     def __init__(self, item=None):
         # type: (Optional[str]) -> None
@@ -516,7 +516,7 @@ class PrimitiveOptionalsExample(ConjureBeanType):
     _bearertoken = None # type: Optional[str]
     _uuid = None # type: Optional[str]
 
-    __slots__ = ['num', 'bool', 'integer', 'safelong', 'rid', 'bearertoken', 'uuid']
+    __slots__ = ['_num', '_bool', '_integer', '_safelong', '_rid', '_bearertoken', '_uuid']
 
     def __init__(self, bearertoken=None, bool=None, integer=None, num=None, rid=None, safelong=None, uuid=None):
         # type: (Optional[str], Optional[bool], Optional[int], Optional[float], Optional[str], Optional[int], Optional[str]) -> None
@@ -574,7 +574,7 @@ class RecursiveObjectExample(ConjureBeanType):
 
     _recursive_field = None # type: Optional[RecursiveObjectAlias]
 
-    __slots__ = ['recursive_field']
+    __slots__ = ['_recursive_field']
 
     def __init__(self, recursive_field=None):
         # type: (Optional[RecursiveObjectAlias]) -> None
@@ -602,7 +602,7 @@ class ReservedKeyExample(ConjureBeanType):
     _field_name_with_dashes = None # type: str
     _memoized_hash_code = None # type: int
 
-    __slots__ = ['package', 'interface', 'field_name_with_dashes', 'memoized_hash_code']
+    __slots__ = ['_package', '_interface', '_field_name_with_dashes', '_memoized_hash_code']
 
     def __init__(self, field_name_with_dashes, interface, memoized_hash_code, package):
         # type: (str, str, int, str) -> None
@@ -642,7 +642,7 @@ class RidExample(ConjureBeanType):
 
     _rid_value = None # type: str
 
-    __slots__ = ['rid_value']
+    __slots__ = ['_rid_value']
 
     def __init__(self, rid_value):
         # type: (str) -> None
@@ -664,7 +664,7 @@ class SafeLongExample(ConjureBeanType):
 
     _safe_long_value = None # type: int
 
-    __slots__ = ['safe_long_value']
+    __slots__ = ['_safe_long_value']
 
     def __init__(self, safe_long_value):
         # type: (int) -> None
@@ -688,7 +688,7 @@ class SetExample(ConjureBeanType):
     _items = None # type: List[str]
     _double_items = None # type: List[float]
 
-    __slots__ = ['items', 'double_items']
+    __slots__ = ['_items', '_double_items']
 
     def __init__(self, double_items, items):
         # type: (List[float], List[str]) -> None
@@ -716,7 +716,7 @@ class StringExample(ConjureBeanType):
 
     _string = None # type: str
 
-    __slots__ = ['string']
+    __slots__ = ['_string']
 
     def __init__(self, string):
         # type: (str) -> None
@@ -751,7 +751,7 @@ class UnionTypeExample(ConjureUnionType):
             'interface': ConjureFieldDefinition('interface', int)
         }
 
-    __slots__ = ['string_example', 'set', 'this_field_is_an_integer', 'also_an_integer', 'if_', 'new', 'interface']
+    __slots__ = ['_string_example', '_set', '_this_field_is_an_integer', '_also_an_integer', '_if_', '_new', '_interface']
 
     def __init__(self, string_example=None, set=None, this_field_is_an_integer=None, also_an_integer=None, if_=None, new=None, interface=None):
         if (string_example is not None) + (set is not None) + (this_field_is_an_integer is not None) + (also_an_integer is not None) + (if_ is not None) + (new is not None) + (interface is not None) != 1:
@@ -884,7 +884,7 @@ class UuidExample(ConjureBeanType):
 
     _uuid = None # type: str
 
-    __slots__ = ['uuid']
+    __slots__ = ['_uuid']
 
     def __init__(self, uuid):
         # type: (str) -> None

--- a/conjure-python-core/src/test/resources/types/expected/package_name/product/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/product/__init__.py
@@ -680,8 +680,6 @@ class UnionTypeExample(ConjureUnionType):
             'interface': ConjureFieldDefinition('interface', int)
         }
 
-    __slots__ = ['_string_example', '_set', '_this_field_is_an_integer', '_also_an_integer', '_if_', '_new', '_interface']
-
     def __init__(self, string_example=None, set=None, this_field_is_an_integer=None, also_an_integer=None, if_=None, new=None, interface=None):
         if (string_example is not None) + (set is not None) + (this_field_is_an_integer is not None) + (also_an_integer is not None) + (if_ is not None) + (new is not None) + (interface is not None) != 1:
             raise ValueError('a union must contain a single member')

--- a/conjure-python-core/src/test/resources/types/expected/package_name/product_datasets/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/product_datasets/__init__.py
@@ -15,6 +15,8 @@ class BackingFileSystem(ConjureBeanType):
     _base_uri = None # type: str
     _configuration = None # type: Dict[str, str]
 
+    __slots__ = ['file_system_id', 'base_uri', 'configuration']
+
     def __init__(self, base_uri, configuration, file_system_id):
         # type: (str, Dict[str, str], str) -> None
         self._file_system_id = file_system_id
@@ -49,6 +51,8 @@ class Dataset(ConjureBeanType):
 
     _file_system_id = None # type: str
     _rid = None # type: str
+
+    __slots__ = ['file_system_id', 'rid']
 
     def __init__(self, file_system_id, rid):
         # type: (str, str) -> None

--- a/conjure-python-core/src/test/resources/types/expected/package_name/product_datasets/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/product_datasets/__init__.py
@@ -15,7 +15,7 @@ class BackingFileSystem(ConjureBeanType):
     _base_uri = None # type: str
     _configuration = None # type: Dict[str, str]
 
-    __slots__ = ['file_system_id', 'base_uri', 'configuration']
+    __slots__ = ['_file_system_id', '_base_uri', '_configuration']
 
     def __init__(self, base_uri, configuration, file_system_id):
         # type: (str, Dict[str, str], str) -> None
@@ -52,7 +52,7 @@ class Dataset(ConjureBeanType):
     _file_system_id = None # type: str
     _rid = None # type: str
 
-    __slots__ = ['file_system_id', 'rid']
+    __slots__ = ['_file_system_id', '_rid']
 
     def __init__(self, file_system_id, rid):
         # type: (str, str) -> None

--- a/conjure-python-core/src/test/resources/types/expected/package_name/product_datasets/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/product_datasets/__init__.py
@@ -11,10 +11,6 @@ class BackingFileSystem(ConjureBeanType):
             'configuration': ConjureFieldDefinition('configuration', DictType(str, str))
         }
 
-    _file_system_id = None # type: str
-    _base_uri = None # type: str
-    _configuration = None # type: Dict[str, str]
-
     __slots__ = ['_file_system_id', '_base_uri', '_configuration']
 
     def __init__(self, base_uri, configuration, file_system_id):
@@ -48,9 +44,6 @@ class Dataset(ConjureBeanType):
             'file_system_id': ConjureFieldDefinition('fileSystemId', str),
             'rid': ConjureFieldDefinition('rid', str)
         }
-
-    _file_system_id = None # type: str
-    _rid = None # type: str
 
     __slots__ = ['_file_system_id', '_rid']
 

--- a/conjure-python-core/src/test/resources/types/expected/package_name/with_imports/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/with_imports/__init__.py
@@ -13,9 +13,6 @@ class ComplexObjectWithImports(ConjureBeanType):
             'imported': ConjureFieldDefinition('imported', StringExample)
         }
 
-    _string = None # type: str
-    _imported = None # type: StringExample
-
     __slots__ = ['_string', '_imported']
 
     def __init__(self, imported, string):
@@ -72,8 +69,6 @@ class ImportedAliasInMaps(ConjureBeanType):
         return {
             'aliases': ConjureFieldDefinition('aliases', DictType(RidAliasExample, DateTimeAliasExample))
         }
-
-    _aliases = None # type: Dict[RidAliasExample, DateTimeAliasExample]
 
     __slots__ = ['_aliases']
 

--- a/conjure-python-core/src/test/resources/types/expected/package_name/with_imports/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/with_imports/__init__.py
@@ -16,7 +16,7 @@ class ComplexObjectWithImports(ConjureBeanType):
     _string = None # type: str
     _imported = None # type: StringExample
 
-    __slots__ = ['string', 'imported']
+    __slots__ = ['_string', '_imported']
 
     def __init__(self, imported, string):
         # type: (StringExample, str) -> None
@@ -75,7 +75,7 @@ class ImportedAliasInMaps(ConjureBeanType):
 
     _aliases = None # type: Dict[RidAliasExample, DateTimeAliasExample]
 
-    __slots__ = ['aliases']
+    __slots__ = ['_aliases']
 
     def __init__(self, aliases):
         # type: (Dict[RidAliasExample, DateTimeAliasExample]) -> None
@@ -99,7 +99,7 @@ class UnionWithImports(ConjureUnionType):
             'imported': ConjureFieldDefinition('imported', AnyMapExample)
         }
 
-    __slots__ = ['string', 'imported']
+    __slots__ = ['_string', '_imported']
 
     def __init__(self, string=None, imported=None):
         if (string is not None) + (imported is not None) != 1:

--- a/conjure-python-core/src/test/resources/types/expected/package_name/with_imports/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/with_imports/__init__.py
@@ -16,6 +16,8 @@ class ComplexObjectWithImports(ConjureBeanType):
     _string = None # type: str
     _imported = None # type: StringExample
 
+    __slots__ = ['string', 'imported']
+
     def __init__(self, imported, string):
         # type: (StringExample, str) -> None
         self._string = string
@@ -73,6 +75,8 @@ class ImportedAliasInMaps(ConjureBeanType):
 
     _aliases = None # type: Dict[RidAliasExample, DateTimeAliasExample]
 
+    __slots__ = ['aliases']
+
     def __init__(self, aliases):
         # type: (Dict[RidAliasExample, DateTimeAliasExample]) -> None
         self._aliases = aliases
@@ -94,6 +98,8 @@ class UnionWithImports(ConjureUnionType):
             'string': ConjureFieldDefinition('string', str),
             'imported': ConjureFieldDefinition('imported', AnyMapExample)
         }
+
+    __slots__ = ['string', 'imported']
 
     def __init__(self, string=None, imported=None):
         if (string is not None) + (imported is not None) != 1:

--- a/conjure-python-core/src/test/resources/types/expected/package_name/with_imports/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/with_imports/__init__.py
@@ -94,8 +94,6 @@ class UnionWithImports(ConjureUnionType):
             'imported': ConjureFieldDefinition('imported', AnyMapExample)
         }
 
-    __slots__ = ['_string', '_imported']
-
     def __init__(self, string=None, imported=None):
         if (string is not None) + (imported is not None) != 1:
             raise ValueError('a union must contain a single member')


### PR DESCRIPTION
Closes #47 

## Before this PR
We were permissive and allowed users to augment conjure objects with additional fields

## After this PR
Attempting to add fields to a conjure bean/union will fail. We also get a nice perf win since the objects are no longer modeled as dictionaries 
