### PR TITLE
[fix] put docs on separate line from block comment marker

### DIFF
--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonService.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonService.java
@@ -53,7 +53,11 @@ public interface PythonService extends PythonSnippet {
         poetWriter.maintainingIndent(() -> {
             poetWriter.writeIndentedLine(String.format("class %s(Service):", className()));
             poetWriter.increaseIndent();
-            docs().ifPresent(docs -> poetWriter.writeIndentedLine(String.format("\"\"\"%s\"\"\"", docs.get().trim())));
+            docs().ifPresent(docs -> {
+                poetWriter.writeIndentedLine("\"\"\"");
+                poetWriter.writeIndentedLine(docs.get().trim());
+                poetWriter.writeIndentedLine("\"\"\"");
+            });
 
             endpointDefinitions().forEach(endpointDefinition -> {
                 poetWriter.writeLine();

--- a/conjure-python-core/src/test/resources/services/expected/package_name/another/__init__.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/another/__init__.py
@@ -4,7 +4,9 @@ from conjure_python_client import BinaryType, ConjureDecoder, ConjureEncoder, Di
 from typing import Any, Dict, Optional, Set
 
 class TestService(Service):
-    """A Markdown description of the service."""
+    """
+    A Markdown description of the service. "Might end with quotes"
+    """
 
     def get_file_systems(self, auth_header):
         # type: (str) -> Dict[str, BackingFileSystem]

--- a/conjure-python-core/src/test/resources/types/example-service.yml
+++ b/conjure-python-core/src/test/resources/types/example-service.yml
@@ -50,7 +50,7 @@ services:
     default-auth: header
     base-path: /catalog
     docs: |
-      A Markdown description of the service.
+      A Markdown description of the service. "Might end with quotes"
 
     endpoints:
       getFileSystems:

--- a/conjure-python-core/src/test/resources/types/expected/package_name/another/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/another/__init__.py
@@ -4,7 +4,9 @@ from conjure_python_client import BinaryType, ConjureDecoder, ConjureEncoder, Di
 from typing import Any, Dict, Optional, Set
 
 class TestService(Service):
-    """A Markdown description of the service."""
+    """
+    A Markdown description of the service. "Might end with quotes"
+    """
 
     def get_file_systems(self, auth_header):
         # type: (str) -> Dict[str, BackingFileSystem]


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
<!-- Describe the problem you encountered with the current state of the world (or link to an issue) and why it's important to fix now. -->

Conjure documentation strings that happened to begin or end with a quote symbol (`"`) would break block comment escaping and cause the interpreter to fail.

```yml
 ...
 docs: These are the docs "this part is quoted"
 ...
```

renders in python as 

```python
	"""These are the docs "this part is quoted""""
```

and the interpreter says:

```python
SyntaxError: EOL while scanning string literal
```

## After this PR
<!-- Describe at a high-level why this approach is better. -->

By putting the docstring on a separate line from the block comment markers we avoid this conflict.


```python
	"""
	These are the docs "this part is quoted"
	"""
```

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
