### PR TITLE
[fix] topologically sort aliases

### DIFF
--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/PythonAliasTopologicalSorter.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/PythonAliasTopologicalSorter.java
@@ -50,7 +50,7 @@ public final class PythonAliasTopologicalSorter {
         snippets.forEach(mutableGraph::addNode);
         snippets.forEach(snippet -> snippet.aliasType().getAlias().accept(aliasEdgeVisitor).stream()
                 .filter(dependant -> !dependant.equals(snippet))
-                .forEach(dependant -> mutableGraph.putEdge(snippet, dependant)));
+                .forEach(dependant -> mutableGraph.putEdge(dependant, snippet)));
 
         ImmutableList.Builder<AliasSnippet> outputBuilder = ImmutableList.builder();
         Set<AliasSnippet> roots = mutableGraph.nodes().stream()

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/PythonAliasTopologicalSorter.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/PythonAliasTopologicalSorter.java
@@ -1,0 +1,136 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.python;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.graph.ElementOrder;
+import com.google.common.graph.GraphBuilder;
+import com.google.common.graph.MutableGraph;
+import com.palantir.conjure.python.poet.AliasSnippet;
+import com.palantir.conjure.spec.ExternalReference;
+import com.palantir.conjure.spec.ListType;
+import com.palantir.conjure.spec.MapType;
+import com.palantir.conjure.spec.OptionalType;
+import com.palantir.conjure.spec.PrimitiveType;
+import com.palantir.conjure.spec.SetType;
+import com.palantir.conjure.spec.Type;
+import com.palantir.conjure.spec.TypeName;
+import com.palantir.conjure.visitor.TypeVisitor;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public final class PythonAliasTopologicalSorter {
+    private PythonAliasTopologicalSorter() {}
+
+    public static List<AliasSnippet> getSortedSnippets(List<AliasSnippet> snippets) {
+        AliasEdgeVisitor aliasEdgeVisitor = new AliasEdgeVisitor(snippets);
+        MutableGraph<AliasSnippet> mutableGraph = GraphBuilder.directed()
+                .nodeOrder(ElementOrder.insertion())
+                .build();
+
+        snippets.forEach(mutableGraph::addNode);
+        snippets.forEach(snippet -> snippet.aliasType().accept(aliasEdgeVisitor).stream()
+                .filter(dependant -> !dependant.equals(snippet))
+                .forEach(dependant -> mutableGraph.putEdge(snippet, dependant)));
+
+        ImmutableList.Builder<AliasSnippet> outputBuilder = ImmutableList.builder();
+        Set<AliasSnippet> roots = mutableGraph.nodes().stream()
+                .filter(node -> mutableGraph.inDegree(node) == 0)
+                .collect(Collectors.toSet());
+
+        // Kahn's Algorithm https://en.wikipedia.org/wiki/Topological_sorting#Kahn's_algorithm
+        while (!roots.isEmpty()) {
+            AliasSnippet currentNode = Iterables.getFirst(roots, null);
+            roots.remove(currentNode);
+            outputBuilder.add(currentNode);
+            for (AliasSnippet successor : mutableGraph.successors(currentNode)) {
+                mutableGraph.removeEdge(currentNode, successor);
+                if (mutableGraph.predecessors(successor).isEmpty()) {
+                    roots.add(successor);
+                }
+            }
+        }
+
+        Preconditions.checkState(mutableGraph.edges().isEmpty(), "graph has at least one cycle");
+        return outputBuilder.build();
+    }
+
+    static class AliasEdgeVisitor implements Type.Visitor<List<AliasSnippet>> {
+        private final Map<Type, AliasSnippet> knownAliases;
+
+        AliasEdgeVisitor(List<AliasSnippet> snippets) {
+            knownAliases = snippets.stream()
+                    .collect(Collectors.toMap(AliasSnippet::aliasType, Function.identity()));
+        }
+
+        @Override
+        public List<AliasSnippet> visitPrimitive(PrimitiveType value) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public List<AliasSnippet> visitOptional(OptionalType value) {
+            return value.getItemType().accept(this);
+        }
+
+        @Override
+        public List<AliasSnippet> visitList(ListType value) {
+            return value.getItemType().accept(this);
+        }
+
+        @Override
+        public List<AliasSnippet> visitSet(SetType value) {
+            return value.getItemType().accept(this);
+        }
+
+        @Override
+        public List<AliasSnippet> visitMap(MapType value) {
+            return ImmutableList.<AliasSnippet>builder()
+                    .addAll(value.getValueType().accept(this))
+                    .addAll(value.getKeyType().accept(this))
+                    .build();
+        }
+
+        @Override
+        public List<AliasSnippet> visitReference(TypeName value) {
+            Optional<Type> first = knownAliases.keySet().stream()
+                    .filter(type -> type.accept(TypeVisitor.IS_REFERENCE) && type.accept(TypeVisitor.REFERENCE).equals(
+                            value))
+                    .findFirst();
+
+            return first.<List<AliasSnippet>>map(type -> ImmutableList.of(knownAliases.get(type)))
+                    .orElse(Collections.emptyList());
+        }
+
+        @Override
+        public List<AliasSnippet> visitExternal(ExternalReference value) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public List<AliasSnippet> visitUnknown(String unknownType) {
+            throw new IllegalStateException("Unknown definition: " + unknownType);
+        }
+    }
+}

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/AliasSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/AliasSnippet.java
@@ -4,6 +4,7 @@
 
 package com.palantir.conjure.python.poet;
 
+import com.palantir.conjure.spec.Type;
 import com.palantir.tokens.auth.ImmutablesStyle;
 import org.immutables.value.Value;
 
@@ -20,6 +21,8 @@ public interface AliasSnippet extends PythonSnippet {
     String className();
 
     String aliasName();
+
+    Type aliasType();
 
     @Override
     default void emit(PythonPoetWriter poetWriter) {

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/AliasSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/AliasSnippet.java
@@ -4,7 +4,7 @@
 
 package com.palantir.conjure.python.poet;
 
-import com.palantir.conjure.spec.Type;
+import com.palantir.conjure.spec.AliasDefinition;
 import com.palantir.tokens.auth.ImmutablesStyle;
 import org.immutables.value.Value;
 
@@ -22,7 +22,7 @@ public interface AliasSnippet extends PythonSnippet {
 
     String aliasName();
 
-    Type aliasType();
+    AliasDefinition aliasType();
 
     @Override
     default void emit(PythonPoetWriter poetWriter) {

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/types/DefaultBeanGenerator.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/types/DefaultBeanGenerator.java
@@ -166,7 +166,7 @@ public final class DefaultBeanGenerator implements PythonBeanGenerator {
         return AliasSnippet.builder()
                 .className(typeDef.getTypeName().getName())
                 .aliasName(typeDef.getAlias().accept(PythonTypeVisitor.PYTHON_TYPE))
-                .aliasType(typeDef.getAlias())
+                .aliasType(typeDef)
                 .imports(ImmutableSet.copyOf(typeDef.getAlias().accept(importVisitor)))
                 .build();
     }

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/types/DefaultBeanGenerator.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/types/DefaultBeanGenerator.java
@@ -166,6 +166,7 @@ public final class DefaultBeanGenerator implements PythonBeanGenerator {
         return AliasSnippet.builder()
                 .className(typeDef.getTypeName().getName())
                 .aliasName(typeDef.getAlias().accept(PythonTypeVisitor.PYTHON_TYPE))
+                .aliasType(typeDef.getAlias())
                 .imports(ImmutableSet.copyOf(typeDef.getAlias().accept(importVisitor)))
                 .build();
     }

--- a/conjure-python-core/src/test/resources/types/example-types.yml
+++ b/conjure-python-core/src/test/resources/types/example-types.yml
@@ -167,3 +167,8 @@ types:
       OptionsUnion:
         union:
           options: string
+      # Importantly NestedAliasExample comes alphabetically before RecursiveObjectAlias
+      NestedAliasExample:
+        alias: RecursiveObjectAlias
+      CollectionAliasExample:
+        alias: map<StringAliasExample, RecursiveObjectAlias>

--- a/conjure-python-core/src/test/resources/types/expected/package_name/product/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/product/__init__.py
@@ -891,17 +891,17 @@ RidAliasExample = str
 
 BinaryAliasExample = BinaryType()
 
-CollectionAliasExample = DictType(StringAliasExample, RecursiveObjectAlias)
-
 SafeLongAliasExample = int
 
 StringAliasExample = str
 
 UuidAliasExample = str
 
-NestedAliasExample = RecursiveObjectAlias
-
 RecursiveObjectAlias = RecursiveObjectExample
+
+CollectionAliasExample = DictType(StringAliasExample, RecursiveObjectAlias)
+
+NestedAliasExample = RecursiveObjectAlias
 
 BearerTokenAliasExample = str
 

--- a/conjure-python-core/src/test/resources/types/expected/package_name/product/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/product/__init__.py
@@ -887,33 +887,33 @@ class UuidExample(ConjureBeanType):
         # type: () -> str
         return self._uuid
 
-ReferenceAliasExample = AnyExample
-
-BearerTokenAliasExample = str
-
-RecursiveObjectAlias = RecursiveObjectExample
-
 RidAliasExample = str
-
-DoubleAliasExample = float
-
-CollectionAliasExample = DictType(StringAliasExample, RecursiveObjectAlias)
-
-StringAliasExample = str
-
-IntegerAliasExample = int
-
-BooleanAliasExample = bool
 
 BinaryAliasExample = BinaryType()
 
-MapAliasExample = DictType(str, object)
+CollectionAliasExample = DictType(StringAliasExample, RecursiveObjectAlias)
 
 SafeLongAliasExample = int
+
+StringAliasExample = str
 
 UuidAliasExample = str
 
 NestedAliasExample = RecursiveObjectAlias
 
+RecursiveObjectAlias = RecursiveObjectExample
+
+BearerTokenAliasExample = str
+
 DateTimeAliasExample = str
+
+MapAliasExample = DictType(str, object)
+
+ReferenceAliasExample = AnyExample
+
+DoubleAliasExample = float
+
+IntegerAliasExample = int
+
+BooleanAliasExample = bool
 

--- a/conjure-python-core/src/test/resources/types/expected/package_name/product/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/product/__init__.py
@@ -887,29 +887,33 @@ class UuidExample(ConjureBeanType):
         # type: () -> str
         return self._uuid
 
+ReferenceAliasExample = AnyExample
+
 BearerTokenAliasExample = str
-
-BinaryAliasExample = BinaryType()
-
-BooleanAliasExample = bool
-
-DateTimeAliasExample = str
-
-DoubleAliasExample = float
-
-IntegerAliasExample = int
-
-MapAliasExample = DictType(str, object)
 
 RecursiveObjectAlias = RecursiveObjectExample
 
-ReferenceAliasExample = AnyExample
-
 RidAliasExample = str
 
-SafeLongAliasExample = int
+DoubleAliasExample = float
+
+CollectionAliasExample = DictType(StringAliasExample, RecursiveObjectAlias)
 
 StringAliasExample = str
 
+IntegerAliasExample = int
+
+BooleanAliasExample = bool
+
+BinaryAliasExample = BinaryType()
+
+MapAliasExample = DictType(str, object)
+
+SafeLongAliasExample = int
+
 UuidAliasExample = str
+
+NestedAliasExample = RecursiveObjectAlias
+
+DateTimeAliasExample = str
 

--- a/conjure-python-core/src/test/resources/types/expected/package_name/with_imports/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/with_imports/__init__.py
@@ -143,9 +143,9 @@ class UnionWithImportsVisitor(UnionWithImportsVisitorBaseClass):
         pass
 
 
-AliasImportedReferenceAlias = ReferenceAliasExample
-
 AliasImportedObject = ManyFieldExample
 
 AliasImportedPrimitiveAlias = StringAliasExample
+
+AliasImportedReferenceAlias = ReferenceAliasExample
 

--- a/conjure-python-core/src/test/resources/types/expected/package_name/with_imports/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/with_imports/__init__.py
@@ -143,9 +143,9 @@ class UnionWithImportsVisitor(UnionWithImportsVisitorBaseClass):
         pass
 
 
+AliasImportedReferenceAlias = ReferenceAliasExample
+
 AliasImportedObject = ManyFieldExample
 
 AliasImportedPrimitiveAlias = StringAliasExample
-
-AliasImportedReferenceAlias = ReferenceAliasExample
 


### PR DESCRIPTION
Closes #140

## Before this PR
We would generate invalid code when handling nested aliases. This was especially problematic since we did not have previously have type information when we were ordering snippets.

## After this PR
==COMMIT_MSG==
Topologically sort all aliases
==COMMIT_MSG==

## Possible downsides?
The amount of complexity and how much of a hack it is. I think the correct solution is to drop support for python2 and then generate each class in its own file and let python deal with it
