### PR TITLE
Fix: Unions now consistently reference field names

### DIFF
--- a/changelog/@unreleased/pr-221.v2.yml
+++ b/changelog/@unreleased/pr-221.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Unions now consistently reference and initialize their field names.
+  links:
+  - https://github.com/palantir/conjure-python/pull/221

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
@@ -99,7 +99,7 @@ public interface UnionSnippet extends PythonSnippet {
         for (int i = 0; i < options().size(); i++) {
             PythonField option = options().get(i);
             poetWriter.writeIndentedLine("'%s': ConjureFieldDefinition('%s', %s)%s",
-                    parameterName(option),
+                    propertyName(option),
                     option.jsonIdentifier(),
                     option.pythonType(),
                     i == options().size() - 1 ? "" : ",");

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
@@ -56,12 +56,24 @@ public interface UnionSnippet extends PythonSnippet {
 
     List<PythonField> options();
 
+    /** The name of the option as a constructor / method parameter. */
     static String parameterName(PythonField option) {
         return PythonIdentifierSanitizer.sanitize(option.attributeName());
     }
 
+    /** The name of the option as a {@code @property}. Must be different from {@link #fieldName}. */
+    static String propertyName(PythonField option) {
+        return PythonIdentifierSanitizer.sanitize(option.attributeName());
+    }
+
+    /** The name of the option as a field. */
     static String fieldName(PythonField option) {
         return "_" + PythonIdentifierSanitizer.sanitize(option.attributeName(), PROTECTED_FIELDS);
+    }
+
+    /** The name of the visitor method for the given option. */
+    static String visitorMethodName(PythonField option) {
+        return "_" + option.attributeName();
     }
 
     @Override
@@ -132,7 +144,7 @@ public interface UnionSnippet extends PythonSnippet {
         options().forEach(option -> {
             poetWriter.writeLine();
             poetWriter.writeIndentedLine("@property");
-            poetWriter.writeIndentedLine(String.format("def %s(self):", parameterName(option)));
+            poetWriter.writeIndentedLine(String.format("def %s(self):", propertyName(option)));
 
             poetWriter.increaseIndent();
             poetWriter.writeIndentedLine(String.format("# type: () -> %s", option.myPyType()));
@@ -157,7 +169,7 @@ public interface UnionSnippet extends PythonSnippet {
         options().forEach(option -> {
             poetWriter.writeIndentedLine("if self.type == '%s':", option.jsonIdentifier());
             poetWriter.increaseIndent();
-            poetWriter.writeIndentedLine("return visitor.%s(self.%s)", fieldName(option), parameterName(option));
+            poetWriter.writeIndentedLine("return visitor.%s(self.%s)", visitorMethodName(option), propertyName(option));
             poetWriter.decreaseIndent();
         });
         poetWriter.decreaseIndent();
@@ -177,7 +189,7 @@ public interface UnionSnippet extends PythonSnippet {
         options().forEach(option -> {
             poetWriter.writeLine();
             poetWriter.writeIndentedLine("@abstractmethod");
-            poetWriter.writeIndentedLine("def %s(self, %s):", fieldName(option), parameterName(option));
+            poetWriter.writeIndentedLine("def %s(self, %s):", visitorMethodName(option), parameterName(option));
             poetWriter.increaseIndent();
             poetWriter.writeIndentedLine("# type: (%s) -> Any", option.myPyType());
             poetWriter.writeIndentedLine("pass");

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
@@ -56,6 +56,14 @@ public interface UnionSnippet extends PythonSnippet {
 
     List<PythonField> options();
 
+    static String parameterName(PythonField option) {
+        return PythonIdentifierSanitizer.sanitize(option.attributeName());
+    }
+
+    static String fieldName(PythonField option) {
+        return "_" + PythonIdentifierSanitizer.sanitize(option.attributeName(), PROTECTED_FIELDS);
+    }
+
     @Override
     default void emit(PythonPoetWriter poetWriter) {
         poetWriter.writeIndentedLine(String.format("class %s(ConjureUnionType):", className()));
@@ -64,8 +72,8 @@ public interface UnionSnippet extends PythonSnippet {
 
         poetWriter.writeLine();
 
-        options().forEach(option -> poetWriter.writeIndentedLine("_%s = None # type: %s",
-                option.attributeName(), option.myPyType()));
+        options().forEach(option -> poetWriter.writeIndentedLine("%s = None # type: %s",
+                fieldName(option), option.myPyType()));
 
         poetWriter.writeLine();
 
@@ -79,7 +87,7 @@ public interface UnionSnippet extends PythonSnippet {
         for (int i = 0; i < options().size(); i++) {
             PythonField option = options().get(i);
             poetWriter.writeIndentedLine("'%s': ConjureFieldDefinition('%s', %s)%s",
-                    PythonIdentifierSanitizer.sanitize(option.attributeName()),
+                    parameterName(option),
                     option.jsonIdentifier(),
                     option.pythonType(),
                     i == options().size() - 1 ? "" : ",");
@@ -103,8 +111,7 @@ public interface UnionSnippet extends PythonSnippet {
         poetWriter.writeIndentedLine("if %s != 1:",
                 Joiner.on(" + ").join(
                     options().stream()
-                        .map(option -> String.format("(%s is not None)",
-                                PythonIdentifierSanitizer.sanitize(option.attributeName())))
+                        .map(option -> String.format("(%s is not None)", parameterName(option)))
                         .collect(Collectors.toList())));
         poetWriter.increaseIndent();
         poetWriter.writeIndentedLine("raise ValueError('a union must contain a single member')");
@@ -113,12 +120,9 @@ public interface UnionSnippet extends PythonSnippet {
         poetWriter.writeLine();
         // save off
         options().forEach(option -> {
-            poetWriter.writeIndentedLine("if %s is not None:",
-                    PythonIdentifierSanitizer.sanitize(option.attributeName()));
+            poetWriter.writeIndentedLine("if %s is not None:", parameterName(option));
             poetWriter.increaseIndent();
-            poetWriter.writeIndentedLine("self._%s = %s",
-                    PythonIdentifierSanitizer.sanitize(option.attributeName(), PROTECTED_FIELDS),
-                    PythonIdentifierSanitizer.sanitize(option.attributeName()));
+            poetWriter.writeIndentedLine("self.%s = %s", fieldName(option), parameterName(option));
             poetWriter.writeIndentedLine("self._type = '%s'", option.jsonIdentifier());
             poetWriter.decreaseIndent();
         });
@@ -128,15 +132,13 @@ public interface UnionSnippet extends PythonSnippet {
         options().forEach(option -> {
             poetWriter.writeLine();
             poetWriter.writeIndentedLine("@property");
-            poetWriter.writeIndentedLine(String.format("def %s(self):",
-                    PythonIdentifierSanitizer.sanitize(option.attributeName())));
+            poetWriter.writeIndentedLine(String.format("def %s(self):", parameterName(option)));
 
             poetWriter.increaseIndent();
             poetWriter.writeIndentedLine(String.format("# type: () -> %s", option.myPyType()));
             option.docs().ifPresent(docs -> poetWriter.writeIndentedLine(String.format("\"\"\"%s\"\"\"",
                     docs.get().trim())));
-            poetWriter.writeIndentedLine(String.format("return self._%s",
-                    PythonIdentifierSanitizer.sanitize(option.attributeName(), PROTECTED_FIELDS)));
+            poetWriter.writeIndentedLine(String.format("return self.%s", fieldName(option)));
             poetWriter.decreaseIndent();
         });
 
@@ -155,8 +157,7 @@ public interface UnionSnippet extends PythonSnippet {
         options().forEach(option -> {
             poetWriter.writeIndentedLine("if self.type == '%s':", option.jsonIdentifier());
             poetWriter.increaseIndent();
-            poetWriter.writeIndentedLine("return visitor._%s(self.%s)", option.attributeName(),
-                    PythonIdentifierSanitizer.sanitize(option.attributeName()));
+            poetWriter.writeIndentedLine("return visitor.%s(self.%s)", fieldName(option), parameterName(option));
             poetWriter.decreaseIndent();
         });
         poetWriter.decreaseIndent();
@@ -176,8 +177,7 @@ public interface UnionSnippet extends PythonSnippet {
         options().forEach(option -> {
             poetWriter.writeLine();
             poetWriter.writeIndentedLine("@abstractmethod");
-            poetWriter.writeIndentedLine("def _%s(self, %s):", option.attributeName(),
-                    PythonIdentifierSanitizer.sanitize(option.attributeName()));
+            poetWriter.writeIndentedLine("def %s(self, %s):", fieldName(option), parameterName(option));
             poetWriter.increaseIndent();
             poetWriter.writeIndentedLine("# type: (%s) -> Any", option.myPyType());
             poetWriter.writeIndentedLine("pass");

--- a/conjure-python-core/src/test/resources/types/example-types.yml
+++ b/conjure-python-core/src/test/resources/types/example-types.yml
@@ -1,4 +1,3 @@
-# don't forget to update conjure-python/src/test/resources/types/example-types.yml
 types:
   definitions:
     default-package: com.palantir.product

--- a/conjure-python-core/src/test/resources/types/expected/package_name/product/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/product/__init__.py
@@ -469,7 +469,7 @@ class OptionalExample(ConjureBeanType):
 
 class OptionsUnion(ConjureUnionType):
 
-    _options = None # type: str
+    _options_ = None # type: str
 
     @builtins.classmethod
     def _options(cls):
@@ -727,7 +727,7 @@ class UnionTypeExample(ConjureUnionType):
     _set = None # type: List[str]
     _this_field_is_an_integer = None # type: int
     _also_an_integer = None # type: int
-    _if = None # type: int
+    _if_ = None # type: int
     _new = None # type: int
     _interface = None # type: int
 


### PR DESCRIPTION
## Before this PR

Unions would define the field for a protected option name (like `if`) as `_if` but the constructor logic would try to assign it to `self._if_`. See #220.

## After this PR
==COMMIT_MSG==
Unions now consistently reference and initialize their field names.
==COMMIT_MSG==

Fixes #220.

## Future work

Looking at this I've discovered that a union variant called `type` is completely broken.
This edge case is not mentioned in [the yml definition spec](https://palantir.github.io/conjure/#/docs/spec/conjure_definitions?id=uniontypedefinition) nor in [the wire format](https://palantir.github.io/conjure/#/docs/spec/wire?id=_54-union-json-format).
Note that even if we mark `type` as a protected field so a variant called `type` doesn't clobber the field `self._type` that identifies which union variant was chosen, the JSON representation for such a variant would be `type` which conflicts in the same way at the JSON level.

(this has already been flagged it looks like: https://github.com/palantir/conjure/issues/179)

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

