### PR TITLE
Handle empty unions

### DIFF
--- a/conjure-python-core/src/test/resources/types/example-types.yml
+++ b/conjure-python-core/src/test/resources/types/example-types.yml
@@ -135,6 +135,8 @@ types:
           interface: integer
       EmptyObjectExample:
         fields: {}
+      EmptyUnionExample:
+        union: {}
       AliasAsMapKeyExample:
         fields:
           strings: map<StringAliasExample, ManyFieldExample>


### PR DESCRIPTION
## Before this PR
Empty union types pass conjure validation, but fail to produce valid python source

## After this PR
Either fail validation, or generate valid source

