### PR TITLE
Fix __all__ generation in root init file

### DIFF
--- a/changelog/@unreleased/pr-330.v2.yml
+++ b/changelog/@unreleased/pr-330.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: We now only match the first occurence of the root pacakage name, rather
+    than all occurences in the subpackage name.
+  links:
+  - https://github.com/palantir/conjure-python/pull/330

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/ConjurePythonGenerator.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/ConjurePythonGenerator.java
@@ -228,7 +228,7 @@ public final class ConjurePythonGenerator {
                         .contents(packageNames.stream()
                                 .map(pythonPackage -> pythonPackage
                                         .get()
-                                        .replace(rootInitFilePath, "")
+                                        .replaceFirst(rootInitFilePath, "")
                                         .replace(".", ""))
                                 .sorted()
                                 .collect(Collectors.toList()))

--- a/conjure-python-core/src/test/resources/services/expected/package_name/__init__.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/__init__.py
@@ -1,5 +1,6 @@
 __all__ = [
     'another',
+    'package_name',
     'product',
     'product_datasets',
 ]

--- a/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
@@ -565,3 +565,5 @@ product_datasets_Dataset.__name__ = "Dataset"
 product_datasets_Dataset.__module__ = "package_name.product_datasets"
 
 
+package_name_TypeInPackageWithTheSameNameAsRootPackage = str
+

--- a/conjure-python-core/src/test/resources/services/expected/package_name/package_name/__init__.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/package_name/__init__.py
@@ -1,0 +1,4 @@
+from .._impl import (
+    package_name_TypeInPackageWithTheSameNameAsRootPackage as TypeInPackageWithTheSameNameAsRootPackage,
+)
+

--- a/conjure-python-core/src/test/resources/types/example-service.yml
+++ b/conjure-python-core/src/test/resources/types/example-service.yml
@@ -43,6 +43,10 @@ types:
           fileSystemId: string
           path: string
 
+      TypeInPackageWithTheSameNameAsRootPackage:
+        package: com.palantir.package.name
+        alias: string
+
 services:
   TestService:
     name: Test Service

--- a/conjure-python-core/src/test/resources/types/expected/package_name/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/__init__.py
@@ -3,6 +3,7 @@ __all__ = [
     'nested_deeply_nested_service',
     'nested_service',
     'nested_service2',
+    'package_name',
     'product',
     'product_datasets',
     'with_imports',

--- a/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
@@ -1898,6 +1898,8 @@ product_UuidAliasExample = str
 
 product_CollectionAliasExample = DictType(product_StringAliasExample, product_RecursiveObjectAlias)
 
+package_name_TypeInPackageWithTheSameNameAsRootPackage = str
+
 product_ReferenceAliasExample = product_AnyExample
 
 product_RidAliasExample = str

--- a/conjure-python-core/src/test/resources/types/expected/package_name/package_name/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/package_name/__init__.py
@@ -1,0 +1,4 @@
+from .._impl import (
+    package_name_TypeInPackageWithTheSameNameAsRootPackage as TypeInPackageWithTheSameNameAsRootPackage,
+)
+

--- a/conjure-python-verifier/python/test/client/test_import_all.py
+++ b/conjure-python-verifier/python/test/client/test_import_all.py
@@ -1,0 +1,4 @@
+from ..generated_integration import *
+
+def test():
+    pass  # we just need to confirm that the above import didn't fail

--- a/conjure-python-verifier/src/main/conjure/package-with-same-name-as-root-package.conjure.yml
+++ b/conjure-python-verifier/src/main/conjure/package-with-same-name-as-root-package.conjure.yml
@@ -1,0 +1,7 @@
+types:
+  definitions:
+    default-package: com.palantir.generated.integration.subpackage
+    objects:
+      SomeObject:
+        fields:
+          string: string


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
If the root package name was the same as any subpackage we would inadvertently replace that portion of the package name with an empty string.

## After this PR
==COMMIT_MSG==
We now only match the first occurence of the root pacakage name, rather than all occurences in the subpackage name.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

