### PR TITLE
new --minimumPythonVersion flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,13 @@ The recommended way to use conjure-python is via a build tool like [gradle-conju
 
     Usage: conjure-python generate <input> <output> [...options]
 
-        --packageName         package name that will appear in setup.py
-        --packageVersion      version number that will appear in setup.py
-        --packageDescription  description that will appear in setup.py
-        --packageUrl          url that will appear in setup.py
-        --packageAuthor       author that will appear in setup.py
-        --writeCondaRecipe    use this boolean option to generate a `conda_recipe/meta.yaml`
+        --packageName          package name that will appear in setup.py
+        --packageVersion       version number that will appear in setup.py
+        --packageDescription   description that will appear in setup.py
+        --packageUrl           url that will appear in setup.py
+        --packageAuthor        author that will appear in setup.py
+        --writeCondaRecipe     use this boolean option to generate a `conda_recipe/meta.yaml`
+        --minimumPythonVersion generated code must be usable on this python version (i.e. ASCII only source for python 2)
 
 ## Example generated objects
 

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/DefaultPythonFileWriter.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/DefaultPythonFileWriter.java
@@ -21,15 +21,19 @@ import com.palantir.conjure.python.poet.PythonPoetWriter;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
 public final class DefaultPythonFileWriter implements PythonFileWriter {
 
     private final Path basePath;
+    private final Charset charset;
 
-    public DefaultPythonFileWriter(Path basePath) {
+    public DefaultPythonFileWriter(Path basePath, int minimumPythonVersion) {
         this.basePath = basePath;
+        this.charset = minimumPythonVersion == 2 ? StandardCharsets.US_ASCII : StandardCharsets.UTF_8;
     }
 
     @Override
@@ -38,7 +42,7 @@ public final class DefaultPythonFileWriter implements PythonFileWriter {
         try {
             Files.createDirectories(filePath.getParent());
             try (OutputStream os = Files.newOutputStream(filePath);
-                    PrintStream ps = new PrintStream(os)) {
+                    PrintStream ps = new PrintStream(os, false, charset.toString())) {
                 PythonPoetWriter writer = new PythonPoetWriter(ps);
                 writer.emit(file);
             }

--- a/conjure-python-core/src/test/java/com/palantir/conjure/python/ConjurePythonGeneratorTest.java
+++ b/conjure-python-core/src/test/java/com/palantir/conjure/python/ConjurePythonGeneratorTest.java
@@ -88,7 +88,7 @@ public final class ConjurePythonGeneratorTest {
             }
             Files.createDirectories(expected);
 
-            generator.write(definition, new DefaultPythonFileWriter(expected));
+            generator.write(definition, new DefaultPythonFileWriter(expected, 3));
         }
     }
 

--- a/conjure-python-core/src/test/java/com/palantir/conjure/python/DefaultPythonFileWriterTest.java
+++ b/conjure-python-core/src/test/java/com/palantir/conjure/python/DefaultPythonFileWriterTest.java
@@ -1,0 +1,54 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.python;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.conjure.python.poet.PythonFile;
+import com.palantir.conjure.python.poet.PythonLine;
+import com.palantir.conjure.python.poet.PythonPackage;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class DefaultPythonFileWriterTest {
+
+    @Rule
+    public final TemporaryFolder folder = new TemporaryFolder();
+
+    private final PythonPackage foo = PythonPackage.of("foo");
+    private final PythonFile file = PythonFile.builder()
+            .pythonPackage(foo)
+            .fileName("test.py")
+            .addContents(
+                    PythonLine.builder().pythonPackage(foo).text("# Emoji: 🌶").build())
+            .build();
+
+    @Test
+    public void special_characters_turn_into_question_marks_for_python_2() {
+        new DefaultPythonFileWriter(folder.getRoot().toPath(), 2).writePythonFile(file);
+
+        assertThat(folder.getRoot().toPath().resolve("foo/test.py")).hasContent("# Emoji: ?\n\n");
+    }
+
+    @Test
+    public void special_characters_preserved_for_python_3() {
+        new DefaultPythonFileWriter(folder.getRoot().toPath(), 3).writePythonFile(file);
+
+        assertThat(folder.getRoot().toPath().resolve("foo/test.py")).hasContent("# Emoji: 🌶\n\n");
+    }
+}

--- a/conjure-python/src/main/java/com/palantir/conjure/python/cli/CliConfiguration.java
+++ b/conjure-python/src/main/java/com/palantir/conjure/python/cli/CliConfiguration.java
@@ -39,6 +39,8 @@ public abstract class CliConfiguration {
 
     abstract Optional<String> packageAuthor();
 
+    abstract int minimumPythonVersion();
+
     @Value.Default
     @SuppressWarnings("DesignForExtension")
     boolean generateRawSource() {
@@ -55,6 +57,10 @@ public abstract class CliConfiguration {
     final void check() {
         Preconditions.checkArgument(input().isFile(), "Target must exist and be a file");
         Preconditions.checkArgument(output().isDirectory(), "Output must exist and be a directory");
+        Preconditions.checkArgument(
+                minimumPythonVersion() == 2 || minimumPythonVersion() == 3,
+                "minimumPythonVersion" + " must be either 2 or 3. Found: %s",
+                minimumPythonVersion());
     }
 
     static Builder builder() {

--- a/conjure-python/src/main/java/com/palantir/conjure/python/cli/ConjurePythonCli.java
+++ b/conjure-python/src/main/java/com/palantir/conjure/python/cli/ConjurePythonCli.java
@@ -89,6 +89,13 @@ public final class ConjurePythonCli implements Runnable {
                 description = "Generate a `conda_recipe/meta.yaml`")
         private boolean writeCondaRecipe;
 
+        @CommandLine.Option(
+                names = "--minimumPythonVersion",
+                defaultValue = "3",
+                description = "generated code must be usable on this python version (i.e. ASCII only source for "
+                        + "python 2)")
+        private int minimumPythonVersion;
+
         @CommandLine.Unmatched
         @SuppressWarnings("StrictUnusedVariable")
         private List<String> unmatchedOptions;
@@ -101,7 +108,9 @@ public final class ConjurePythonCli implements Runnable {
             try {
                 ConjureDefinition conjureDefinition = OBJECT_MAPPER.readValue(new File(input), ConjureDefinition.class);
                 ConjurePythonGenerator generator = new ConjurePythonGenerator(generatorConfig);
-                generator.write(conjureDefinition, new DefaultPythonFileWriter(Paths.get(output)));
+                generator.write(
+                        conjureDefinition,
+                        new DefaultPythonFileWriter(Paths.get(output), cliConfig.minimumPythonVersion()));
             } catch (IOException e) {
                 throw new RuntimeException(String.format("Error parsing definition: %s", e.toString()));
             }
@@ -118,6 +127,7 @@ public final class ConjurePythonCli implements Runnable {
                     .packageUrl(Optional.ofNullable(packageUrl))
                     .generateRawSource(rawSource)
                     .shouldWriteCondaRecipe(writeCondaRecipe)
+                    .minimumPythonVersion(minimumPythonVersion)
                     .build();
         }
 


### PR DESCRIPTION
## Before this PR

eholmer reported in #dev-foundry-infra that they experienced a P0 (PDS-146733):

> o-m-api 0.97.0-0.99.0 included a non-ASCII char in it's python yml/api. This caused py2 v workbooks to fail to run.

```
SyntaxError: Non-ASCII character '\xe2' in file /opt/conda/lib/python2.7/site-packages/<redacted>/_impl.py on line 7219, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details 
```

We discussed in slack a bit and figured this was probably the right place to put this flag.

## After this PR
==COMMIT_MSG==
new `--minimumPythonVersion` flag ensures the generated python code will not contain any special characters which aren't readable by python2.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

