### PR TITLE
Add coding=utf-8 comment as per PEP-0263

### DIFF
--- a/changelog/@unreleased/pr-385.v2.yml
+++ b/changelog/@unreleased/pr-385.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: 'All generated python files now start with a # coding=utf8 comment
+    (as per PEP-0263) to ensure that any special characters in the file are correctly
+    parsed by python 2.'
+  links:
+  - https://github.com/palantir/conjure-python/pull/385

--- a/changelog/@unreleased/pr-385.v2.yml
+++ b/changelog/@unreleased/pr-385.v2.yml
@@ -1,6 +1,6 @@
 type: fix
 fix:
-  description: 'All generated python files now start with a # coding=utf8 comment
+  description: 'All generated python files now start with a `# coding=utf-8` comment
     (as per PEP-0263) to ensure that any special characters in the file are correctly
     parsed by python 2.'
   links:

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/DefaultPythonFileWriter.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/DefaultPythonFileWriter.java
@@ -21,6 +21,7 @@ import com.palantir.conjure.python.poet.PythonPoetWriter;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -38,7 +39,7 @@ public final class DefaultPythonFileWriter implements PythonFileWriter {
         try {
             Files.createDirectories(filePath.getParent());
             try (OutputStream os = Files.newOutputStream(filePath);
-                    PrintStream ps = new PrintStream(os)) {
+                    PrintStream ps = new PrintStream(os, false, StandardCharsets.UTF_8.toString())) {
                 PythonPoetWriter writer = new PythonPoetWriter(ps);
                 writer.emit(file);
             }

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonFile.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonFile.java
@@ -36,7 +36,7 @@ public interface PythonFile extends Emittable {
 
     @Override
     default void emit(PythonPoetWriter poetWriter) {
-        poetWriter.writeLine("# coding=utf8");
+        poetWriter.writeLine("# coding=utf-8");
         poetWriter.maintainingIndent(() -> {
             Map<String, Set<NamedImport>> imports = contents().stream()
                     .flatMap(pythonSnippet -> pythonSnippet.imports().stream())

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonFile.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonFile.java
@@ -36,6 +36,7 @@ public interface PythonFile extends Emittable {
 
     @Override
     default void emit(PythonPoetWriter poetWriter) {
+        poetWriter.writeLine("# coding=utf8");
         poetWriter.maintainingIndent(() -> {
             Map<String, Set<NamedImport>> imports = contents().stream()
                     .flatMap(pythonSnippet -> pythonSnippet.imports().stream())

--- a/conjure-python-core/src/test/resources/services/expected/conda_recipe/meta.yaml
+++ b/conjure-python-core/src/test/resources/services/expected/conda_recipe/meta.yaml
@@ -1,3 +1,4 @@
+# coding=utf8
 package:
     name: package-name
     version: 0.0.0

--- a/conjure-python-core/src/test/resources/services/expected/conda_recipe/meta.yaml
+++ b/conjure-python-core/src/test/resources/services/expected/conda_recipe/meta.yaml
@@ -1,4 +1,4 @@
-# coding=utf8
+# coding=utf-8
 package:
     name: package-name
     version: 0.0.0

--- a/conjure-python-core/src/test/resources/services/expected/package_name/__init__.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/__init__.py
@@ -1,3 +1,4 @@
+# coding=utf8
 __all__ = [
     'another',
     'package_name',

--- a/conjure-python-core/src/test/resources/services/expected/package_name/__init__.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/__init__.py
@@ -1,4 +1,4 @@
-# coding=utf8
+# coding=utf-8
 __all__ = [
     'another',
     'package_name',

--- a/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
@@ -1,4 +1,4 @@
-# coding=utf8
+# coding=utf-8
 import builtins
 from conjure_python_client import (
     BinaryType,

--- a/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
@@ -1,3 +1,4 @@
+# coding=utf8
 import builtins
 from conjure_python_client import (
     BinaryType,

--- a/conjure-python-core/src/test/resources/services/expected/package_name/another/__init__.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/another/__init__.py
@@ -1,3 +1,4 @@
+# coding=utf8
 from .._impl import (
     another_TestService as TestService,
 )

--- a/conjure-python-core/src/test/resources/services/expected/package_name/another/__init__.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/another/__init__.py
@@ -1,4 +1,4 @@
-# coding=utf8
+# coding=utf-8
 from .._impl import (
     another_TestService as TestService,
 )

--- a/conjure-python-core/src/test/resources/services/expected/package_name/package_name/__init__.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/package_name/__init__.py
@@ -1,3 +1,4 @@
+# coding=utf8
 from .._impl import (
     package_name_TypeInPackageWithTheSameNameAsRootPackage as TypeInPackageWithTheSameNameAsRootPackage,
 )

--- a/conjure-python-core/src/test/resources/services/expected/package_name/package_name/__init__.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/package_name/__init__.py
@@ -1,4 +1,4 @@
-# coding=utf8
+# coding=utf-8
 from .._impl import (
     package_name_TypeInPackageWithTheSameNameAsRootPackage as TypeInPackageWithTheSameNameAsRootPackage,
 )

--- a/conjure-python-core/src/test/resources/services/expected/package_name/product/__init__.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/product/__init__.py
@@ -1,4 +1,4 @@
-# coding=utf8
+# coding=utf-8
 from .._impl import (
     product_CreateDatasetRequest as CreateDatasetRequest,
 )

--- a/conjure-python-core/src/test/resources/services/expected/package_name/product/__init__.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/product/__init__.py
@@ -1,3 +1,4 @@
+# coding=utf8
 from .._impl import (
     product_CreateDatasetRequest as CreateDatasetRequest,
 )

--- a/conjure-python-core/src/test/resources/services/expected/package_name/product_datasets/__init__.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/product_datasets/__init__.py
@@ -1,3 +1,4 @@
+# coding=utf8
 from .._impl import (
     product_datasets_BackingFileSystem as BackingFileSystem,
     product_datasets_Dataset as Dataset,

--- a/conjure-python-core/src/test/resources/services/expected/package_name/product_datasets/__init__.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/product_datasets/__init__.py
@@ -1,4 +1,4 @@
-# coding=utf8
+# coding=utf-8
 from .._impl import (
     product_datasets_BackingFileSystem as BackingFileSystem,
     product_datasets_Dataset as Dataset,

--- a/conjure-python-core/src/test/resources/services/expected/setup.py
+++ b/conjure-python-core/src/test/resources/services/expected/setup.py
@@ -1,3 +1,4 @@
+# coding=utf8
 from setuptools import (
     find_packages,
     setup,

--- a/conjure-python-core/src/test/resources/services/expected/setup.py
+++ b/conjure-python-core/src/test/resources/services/expected/setup.py
@@ -1,4 +1,4 @@
-# coding=utf8
+# coding=utf-8
 from setuptools import (
     find_packages,
     setup,

--- a/conjure-python-core/src/test/resources/types/expected/conda_recipe/meta.yaml
+++ b/conjure-python-core/src/test/resources/types/expected/conda_recipe/meta.yaml
@@ -1,3 +1,4 @@
+# coding=utf8
 package:
     name: package-name
     version: 0.0.0

--- a/conjure-python-core/src/test/resources/types/expected/conda_recipe/meta.yaml
+++ b/conjure-python-core/src/test/resources/types/expected/conda_recipe/meta.yaml
@@ -1,4 +1,4 @@
-# coding=utf8
+# coding=utf-8
 package:
     name: package-name
     version: 0.0.0

--- a/conjure-python-core/src/test/resources/types/expected/package_name/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/__init__.py
@@ -1,4 +1,4 @@
-# coding=utf8
+# coding=utf-8
 __all__ = [
     'another',
     'nested_deeply_nested_service',

--- a/conjure-python-core/src/test/resources/types/expected/package_name/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/__init__.py
@@ -1,3 +1,4 @@
+# coding=utf8
 __all__ = [
     'another',
     'nested_deeply_nested_service',

--- a/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
@@ -1,3 +1,4 @@
+# coding=utf8
 from abc import (
     ABCMeta,
     abstractmethod,

--- a/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
@@ -1,4 +1,4 @@
-# coding=utf8
+# coding=utf-8
 from abc import (
     ABCMeta,
     abstractmethod,

--- a/conjure-python-core/src/test/resources/types/expected/package_name/another/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/another/__init__.py
@@ -1,3 +1,4 @@
+# coding=utf8
 from .._impl import (
     another_TestService as TestService,
 )

--- a/conjure-python-core/src/test/resources/types/expected/package_name/another/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/another/__init__.py
@@ -1,4 +1,4 @@
-# coding=utf8
+# coding=utf-8
 from .._impl import (
     another_TestService as TestService,
 )

--- a/conjure-python-core/src/test/resources/types/expected/package_name/nested_deeply_nested_service/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/nested_deeply_nested_service/__init__.py
@@ -1,4 +1,4 @@
-# coding=utf8
+# coding=utf-8
 from .._impl import (
     nested_deeply_nested_service_DeeplyNestedService as DeeplyNestedService,
 )

--- a/conjure-python-core/src/test/resources/types/expected/package_name/nested_deeply_nested_service/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/nested_deeply_nested_service/__init__.py
@@ -1,3 +1,4 @@
+# coding=utf8
 from .._impl import (
     nested_deeply_nested_service_DeeplyNestedService as DeeplyNestedService,
 )

--- a/conjure-python-core/src/test/resources/types/expected/package_name/nested_service/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/nested_service/__init__.py
@@ -1,3 +1,4 @@
+# coding=utf8
 from .._impl import (
     nested_service_SimpleNestedService as SimpleNestedService,
     nested_service_SimpleObject as SimpleObject,

--- a/conjure-python-core/src/test/resources/types/expected/package_name/nested_service/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/nested_service/__init__.py
@@ -1,4 +1,4 @@
-# coding=utf8
+# coding=utf-8
 from .._impl import (
     nested_service_SimpleNestedService as SimpleNestedService,
     nested_service_SimpleObject as SimpleObject,

--- a/conjure-python-core/src/test/resources/types/expected/package_name/nested_service2/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/nested_service2/__init__.py
@@ -1,4 +1,4 @@
-# coding=utf8
+# coding=utf-8
 from .._impl import (
     nested_service2_SimpleNestedService2 as SimpleNestedService2,
 )

--- a/conjure-python-core/src/test/resources/types/expected/package_name/nested_service2/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/nested_service2/__init__.py
@@ -1,3 +1,4 @@
+# coding=utf8
 from .._impl import (
     nested_service2_SimpleNestedService2 as SimpleNestedService2,
 )

--- a/conjure-python-core/src/test/resources/types/expected/package_name/package_name/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/package_name/__init__.py
@@ -1,3 +1,4 @@
+# coding=utf8
 from .._impl import (
     package_name_TypeInPackageWithTheSameNameAsRootPackage as TypeInPackageWithTheSameNameAsRootPackage,
 )

--- a/conjure-python-core/src/test/resources/types/expected/package_name/package_name/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/package_name/__init__.py
@@ -1,4 +1,4 @@
-# coding=utf8
+# coding=utf-8
 from .._impl import (
     package_name_TypeInPackageWithTheSameNameAsRootPackage as TypeInPackageWithTheSameNameAsRootPackage,
 )

--- a/conjure-python-core/src/test/resources/types/expected/package_name/product/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/product/__init__.py
@@ -1,3 +1,4 @@
+# coding=utf8
 from .._impl import (
     product_AliasAsMapKeyExample as AliasAsMapKeyExample,
     product_AnyExample as AnyExample,

--- a/conjure-python-core/src/test/resources/types/expected/package_name/product/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/product/__init__.py
@@ -1,4 +1,4 @@
-# coding=utf8
+# coding=utf-8
 from .._impl import (
     product_AliasAsMapKeyExample as AliasAsMapKeyExample,
     product_AnyExample as AnyExample,

--- a/conjure-python-core/src/test/resources/types/expected/package_name/product_datasets/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/product_datasets/__init__.py
@@ -1,3 +1,4 @@
+# coding=utf8
 from .._impl import (
     product_datasets_BackingFileSystem as BackingFileSystem,
     product_datasets_Dataset as Dataset,

--- a/conjure-python-core/src/test/resources/types/expected/package_name/product_datasets/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/product_datasets/__init__.py
@@ -1,4 +1,4 @@
-# coding=utf8
+# coding=utf-8
 from .._impl import (
     product_datasets_BackingFileSystem as BackingFileSystem,
     product_datasets_Dataset as Dataset,

--- a/conjure-python-core/src/test/resources/types/expected/package_name/with_imports/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/with_imports/__init__.py
@@ -1,3 +1,4 @@
+# coding=utf8
 from .._impl import (
     with_imports_AliasImportedObject as AliasImportedObject,
     with_imports_AliasImportedPrimitiveAlias as AliasImportedPrimitiveAlias,

--- a/conjure-python-core/src/test/resources/types/expected/package_name/with_imports/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/with_imports/__init__.py
@@ -1,4 +1,4 @@
-# coding=utf8
+# coding=utf-8
 from .._impl import (
     with_imports_AliasImportedObject as AliasImportedObject,
     with_imports_AliasImportedPrimitiveAlias as AliasImportedPrimitiveAlias,

--- a/conjure-python-core/src/test/resources/types/expected/setup.py
+++ b/conjure-python-core/src/test/resources/types/expected/setup.py
@@ -1,3 +1,4 @@
+# coding=utf8
 from setuptools import (
     find_packages,
     setup,

--- a/conjure-python-core/src/test/resources/types/expected/setup.py
+++ b/conjure-python-core/src/test/resources/types/expected/setup.py
@@ -1,4 +1,4 @@
-# coding=utf8
+# coding=utf-8
 from setuptools import (
     find_packages,
     setup,


### PR DESCRIPTION
## Before this PR

eholmer reported in #dev-foundry-infra that they experienced a P0 (PDS-146733):

> o-m-api 0.97.0-0.99.0 included a non-ASCII char in it's python yml/api. This caused py2 v workbooks to fail to run.

```
SyntaxError: Non-ASCII character '\xe2' in file /opt/conda/lib/python2.7/site-packages/<redacted>/_impl.py on line 7219, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details 
```

Initially I was adding a flag https://github.com/palantir/conjure-python/pull/384, but then realised it might be simpler to just always use utf8

## After this PR
==COMMIT_MSG==
All generated python files now start with a `# coding=utf-8` comment (as per PEP-0263) to ensure that any special characters in the file are correctly parsed by python 2.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

