### PR TITLE
Move to non-deprecated picocli methods in main class

### DIFF
--- a/changelog/@unreleased/pr-390.v2.yml
+++ b/changelog/@unreleased/pr-390.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Move to non-deprecated picocli methods in main class
+  links:
+  - https://github.com/palantir/conjure-python/pull/390

--- a/conjure-python/src/main/java/com/palantir/conjure/python/cli/ConjurePythonCli.java
+++ b/conjure-python/src/main/java/com/palantir/conjure/python/cli/ConjurePythonCli.java
@@ -38,7 +38,7 @@ import picocli.CommandLine;
         subcommands = {ConjurePythonCli.GenerateCommand.class})
 public final class ConjurePythonCli implements Runnable {
     public static void main(String[] args) {
-        CommandLine.run(new ConjurePythonCli(), args);
+        System.exit(new CommandLine(new ConjurePythonCli()).execute(args));
     }
 
     @Override

--- a/conjure-python/src/test/java/com/palantir/conjure/python/cli/ConjurePythonCliTest.java
+++ b/conjure-python/src/test/java/com/palantir/conjure/python/cli/ConjurePythonCliTest.java
@@ -113,7 +113,7 @@ public class ConjurePythonCliTest {
             "--packageVersion",
             "0.0.0"
         };
-        new CommandLine(new ConjurePythonCli()).execute(args);
+        assertThat(new CommandLine(new ConjurePythonCli()).execute(args)).isZero();
         assertThat(new File(output, "conjure/conjure_spec/__init__.py").isFile())
                 .isTrue();
     }

--- a/conjure-python/src/test/java/com/palantir/conjure/python/cli/ConjurePythonCliTest.java
+++ b/conjure-python/src/test/java/com/palantir/conjure/python/cli/ConjurePythonCliTest.java
@@ -113,7 +113,7 @@ public class ConjurePythonCliTest {
             "--packageVersion",
             "0.0.0"
         };
-        CommandLine.run(new ConjurePythonCli(), args);
+        new CommandLine(new ConjurePythonCli()).execute(args);
         assertThat(new File(output, "conjure/conjure_spec/__init__.py").isFile())
                 .isTrue();
     }
@@ -124,7 +124,7 @@ public class ConjurePythonCliTest {
         String[] args = {
             "generate", "src/test/resources/conjure-api.json", output.getAbsolutePath(), "--rawSource",
         };
-        CommandLine.run(new ConjurePythonCli(), args);
+        new CommandLine(new ConjurePythonCli()).execute(args);
         assertThat(new File(output, "conjure_spec/__init__.py").isFile()).isTrue();
     }
 

--- a/conjure-python/src/test/java/com/palantir/conjure/python/cli/ConjurePythonCliTest.java
+++ b/conjure-python/src/test/java/com/palantir/conjure/python/cli/ConjurePythonCliTest.java
@@ -124,7 +124,7 @@ public class ConjurePythonCliTest {
         String[] args = {
             "generate", "src/test/resources/conjure-api.json", output.getAbsolutePath(), "--rawSource",
         };
-        new CommandLine(new ConjurePythonCli()).execute(args);
+        assertThat(new CommandLine(new ConjurePythonCli()).execute(args)).isZero();
         assertThat(new File(output, "conjure_spec/__init__.py").isFile()).isTrue();
     }
 


### PR DESCRIPTION
## Before this PR

@razrin reported some gradle-conjure + conjure-python + gradle-conda struggles in #dev-foundry-infra

## After this PR
==COMMIT_MSG==
Move to non-deprecated picocli methods in main class
==COMMIT_MSG==


(I'm not sure this is actually useful for the case in #dev-foundry-infra, just putting it up because resolving deprecations seems net positive)

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

