### PR TITLE
Generate type annotations for union constructors; mark as PEP561

### DIFF
--- a/changelog/@unreleased/pr-467.v2.yml
+++ b/changelog/@unreleased/pr-467.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Mark generated python packages as PEP-561 (type information) compliant;
+    include type information in union constructors
+  links:
+  - https://github.com/palantir/conjure-python/pull/467

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/ConjurePythonGenerator.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/ConjurePythonGenerator.java
@@ -79,6 +79,7 @@ public final class ConjurePythonGenerator {
         PythonPackage rootPackage = PythonPackage.of(buildPackageNameProcessor().process(""));
         if (!config.generateRawSource()) {
             writer.writePythonFile(buildPythonSetupFile(rootPackage));
+            writer.writePythonFile(buildPyTypedFile());
         }
         if (config.shouldWriteCondaRecipe()) {
             writer.writePythonFile(buildCondaMetaYamlFile(rootPackage));
@@ -251,6 +252,10 @@ public final class ConjurePythonGenerator {
                 .pythonPackage(rootPackage)
                 .putOptions("name", config.packageName().get())
                 .putOptions("version", config.packageVersion().get())
+                .putOptions(
+                        "packageData",
+                        String.format(
+                                "{\"%s\": [\"py.typed\"]}", config.packageName().get()))
                 .addInstallDependencies("requests", "typing")
                 .addInstallDependencies(String.format(
                         "conjure-python-client>=%s,<%s",
@@ -264,6 +269,16 @@ public final class ConjurePythonGenerator {
                 .pythonPackage(PythonPackage.of("."))
                 .fileName("setup.py")
                 .addContents(builder.build())
+                .build();
+    }
+
+    /**
+     * Mark a package as containing type annotations.
+     */
+    private PythonFile buildPyTypedFile() {
+        return PythonFile.builder()
+                .pythonPackage(PythonPackage.of(config.pythonicPackageName().get()))
+                .fileName("py.typed")
                 .build();
     }
 

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
@@ -117,15 +117,23 @@ public interface UnionSnippet extends PythonSnippet {
 
             poetWriter.writeLine();
             // constructor
-            poetWriter.writeIndentedLine(String.format(
-                    "def __init__(self, %s):",
-                    Joiner.on(", ")
-                            .join(options().stream()
-                                    .map(PythonField::attributeName)
-                                    .map(PythonIdentifierSanitizer::sanitize)
-                                    .map(attributeName -> String.format("%s=None", attributeName))
-                                    .collect(Collectors.toList()))));
+            poetWriter.writeIndentedLine("def __init__(");
             poetWriter.increaseIndent();
+            poetWriter.increaseIndent();
+            poetWriter.writeIndentedLine("self,");
+            for (int i = 0; i < options().size(); i++) {
+                PythonField option = options().get(i);
+
+                poetWriter.writeIndentedLine(String.format(
+                        "%s=None%s  # type: %s",
+                        PythonIdentifierSanitizer.sanitize(option.attributeName()),
+                        i == options().size() - 1 ? "" : ",",
+                        option.myPyType()));
+            }
+            poetWriter.writeIndentedLine("):");
+            poetWriter.decreaseIndent();
+            poetWriter.writeIndentedLine("# type: (...) -> None");
+
             // check we have exactly one non-null
             poetWriter.writeIndentedLine(
                     "if %s != 1:",

--- a/conjure-python-core/src/test/resources/services/expected/package_name/py.typed
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/py.typed
@@ -1,0 +1,1 @@
+# coding=utf-8

--- a/conjure-python-core/src/test/resources/services/expected/setup.py
+++ b/conjure-python-core/src/test/resources/services/expected/setup.py
@@ -7,6 +7,7 @@ from setuptools import (
 setup(
     name='package-name',
     version='0.0.0',
+    packageData='{"package-name": ["py.typed"]}',
     description='project description',
     packages=find_packages(),
     install_requires=[

--- a/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
@@ -1201,7 +1201,11 @@ class product_OptionsUnion(ConjureUnionType):
             'options': ConjureFieldDefinition('options', str)
         }
 
-    def __init__(self, options=None):
+    def __init__(
+            self,
+            options=None  # type: str
+            ):
+        # type: (...) -> None
         if (options is not None) != 1:
             raise ValueError('a union must contain a single member')
 
@@ -1520,7 +1524,18 @@ class product_UnionTypeExample(ConjureUnionType):
             'property': ConjureFieldDefinition('property', int)
         }
 
-    def __init__(self, string_example=None, set=None, this_field_is_an_integer=None, also_an_integer=None, if_=None, new=None, interface=None, property=None):
+    def __init__(
+            self,
+            string_example=None,  # type: product_StringExample
+            set=None,  # type: List[str]
+            this_field_is_an_integer=None,  # type: int
+            also_an_integer=None,  # type: int
+            if_=None,  # type: int
+            new=None,  # type: int
+            interface=None,  # type: int
+            property=None  # type: int
+            ):
+        # type: (...) -> None
         if (string_example is not None) + (set is not None) + (this_field_is_an_integer is not None) + (also_an_integer is not None) + (if_ is not None) + (new is not None) + (interface is not None) + (property is not None) != 1:
             raise ValueError('a union must contain a single member')
 
@@ -1883,7 +1898,12 @@ class with_imports_UnionWithImports(ConjureUnionType):
             'imported': ConjureFieldDefinition('imported', product_AnyMapExample)
         }
 
-    def __init__(self, string=None, imported=None):
+    def __init__(
+            self,
+            string=None,  # type: str
+            imported=None  # type: product_AnyMapExample
+            ):
+        # type: (...) -> None
         if (string is not None) + (imported is not None) != 1:
             raise ValueError('a union must contain a single member')
 

--- a/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
@@ -1192,7 +1192,7 @@ product_OptionalExample.__module__ = "package_name.product"
 
 
 class product_OptionsUnion(ConjureUnionType):
-    _options_ = None # type: str
+    _options_ = None # type: Optional[str]
 
     @builtins.classmethod
     def _options(cls):
@@ -1203,7 +1203,7 @@ class product_OptionsUnion(ConjureUnionType):
 
     def __init__(
             self,
-            options=None  # type: str
+            options=None  # type: Optional[str]
             ):
         # type: (...) -> None
         if (options is not None) != 1:
@@ -1215,14 +1215,14 @@ class product_OptionsUnion(ConjureUnionType):
 
     @builtins.property
     def options(self):
-        # type: () -> str
+        # type: () -> Optional[str]
         return self._options_
 
     def accept(self, visitor):
         # type: (product_OptionsUnionVisitor) -> Any
         if not isinstance(visitor, product_OptionsUnionVisitor):
             raise ValueError('{} is not an instance of product_OptionsUnionVisitor'.format(visitor.__class__.__name__))
-        if self.type == 'options':
+        if self.options is not None:
             return visitor._options(self.options)
 
 
@@ -1501,14 +1501,14 @@ product_StringExample.__module__ = "package_name.product"
 
 class product_UnionTypeExample(ConjureUnionType):
     """A type which can either be a StringExample, a set of strings, or an integer."""
-    _string_example = None # type: product_StringExample
-    _set = None # type: List[str]
-    _this_field_is_an_integer = None # type: int
-    _also_an_integer = None # type: int
-    _if_ = None # type: int
-    _new = None # type: int
-    _interface = None # type: int
-    _property = None # type: int
+    _string_example = None # type: Optional[product_StringExample]
+    _set = None # type: Optional[List[str]]
+    _this_field_is_an_integer = None # type: Optional[int]
+    _also_an_integer = None # type: Optional[int]
+    _if_ = None # type: Optional[int]
+    _new = None # type: Optional[int]
+    _interface = None # type: Optional[int]
+    _property = None # type: Optional[int]
 
     @builtins.classmethod
     def _options(cls):
@@ -1526,14 +1526,14 @@ class product_UnionTypeExample(ConjureUnionType):
 
     def __init__(
             self,
-            string_example=None,  # type: product_StringExample
-            set=None,  # type: List[str]
-            this_field_is_an_integer=None,  # type: int
-            also_an_integer=None,  # type: int
-            if_=None,  # type: int
-            new=None,  # type: int
-            interface=None,  # type: int
-            property=None  # type: int
+            string_example=None,  # type: Optional[product_StringExample]
+            set=None,  # type: Optional[List[str]]
+            this_field_is_an_integer=None,  # type: Optional[int]
+            also_an_integer=None,  # type: Optional[int]
+            if_=None,  # type: Optional[int]
+            new=None,  # type: Optional[int]
+            interface=None,  # type: Optional[int]
+            property=None  # type: Optional[int]
             ):
         # type: (...) -> None
         if (string_example is not None) + (set is not None) + (this_field_is_an_integer is not None) + (also_an_integer is not None) + (if_ is not None) + (new is not None) + (interface is not None) + (property is not None) != 1:
@@ -1566,7 +1566,7 @@ class product_UnionTypeExample(ConjureUnionType):
 
     @builtins.property
     def string_example(self):
-        # type: () -> product_StringExample
+        # type: () -> Optional[product_StringExample]
         """
         Docs for when UnionTypeExample is of type StringExample.
         """
@@ -1574,58 +1574,58 @@ class product_UnionTypeExample(ConjureUnionType):
 
     @builtins.property
     def set(self):
-        # type: () -> List[str]
+        # type: () -> Optional[List[str]]
         return self._set
 
     @builtins.property
     def this_field_is_an_integer(self):
-        # type: () -> int
+        # type: () -> Optional[int]
         return self._this_field_is_an_integer
 
     @builtins.property
     def also_an_integer(self):
-        # type: () -> int
+        # type: () -> Optional[int]
         return self._also_an_integer
 
     @builtins.property
     def if_(self):
-        # type: () -> int
+        # type: () -> Optional[int]
         return self._if_
 
     @builtins.property
     def new(self):
-        # type: () -> int
+        # type: () -> Optional[int]
         return self._new
 
     @builtins.property
     def interface(self):
-        # type: () -> int
+        # type: () -> Optional[int]
         return self._interface
 
     @builtins.property
     def property(self):
-        # type: () -> int
+        # type: () -> Optional[int]
         return self._property
 
     def accept(self, visitor):
         # type: (product_UnionTypeExampleVisitor) -> Any
         if not isinstance(visitor, product_UnionTypeExampleVisitor):
             raise ValueError('{} is not an instance of product_UnionTypeExampleVisitor'.format(visitor.__class__.__name__))
-        if self.type == 'stringExample':
+        if self.string_example is not None:
             return visitor._string_example(self.string_example)
-        if self.type == 'set':
+        if self.set is not None:
             return visitor._set(self.set)
-        if self.type == 'thisFieldIsAnInteger':
+        if self.this_field_is_an_integer is not None:
             return visitor._this_field_is_an_integer(self.this_field_is_an_integer)
-        if self.type == 'alsoAnInteger':
+        if self.also_an_integer is not None:
             return visitor._also_an_integer(self.also_an_integer)
-        if self.type == 'if':
+        if self.if_ is not None:
             return visitor._if(self.if_)
-        if self.type == 'new':
+        if self.new is not None:
             return visitor._new(self.new)
-        if self.type == 'interface':
+        if self.interface is not None:
             return visitor._interface(self.interface)
-        if self.type == 'property':
+        if self.property is not None:
             return visitor._property(self.property)
 
 
@@ -1887,8 +1887,8 @@ with_imports_ImportedAliasInMaps.__module__ = "package_name.with_imports"
 
 
 class with_imports_UnionWithImports(ConjureUnionType):
-    _string = None # type: str
-    _imported = None # type: product_AnyMapExample
+    _string = None # type: Optional[str]
+    _imported = None # type: Optional[product_AnyMapExample]
 
     @builtins.classmethod
     def _options(cls):
@@ -1900,8 +1900,8 @@ class with_imports_UnionWithImports(ConjureUnionType):
 
     def __init__(
             self,
-            string=None,  # type: str
-            imported=None  # type: product_AnyMapExample
+            string=None,  # type: Optional[str]
+            imported=None  # type: Optional[product_AnyMapExample]
             ):
         # type: (...) -> None
         if (string is not None) + (imported is not None) != 1:
@@ -1916,21 +1916,21 @@ class with_imports_UnionWithImports(ConjureUnionType):
 
     @builtins.property
     def string(self):
-        # type: () -> str
+        # type: () -> Optional[str]
         return self._string
 
     @builtins.property
     def imported(self):
-        # type: () -> product_AnyMapExample
+        # type: () -> Optional[product_AnyMapExample]
         return self._imported
 
     def accept(self, visitor):
         # type: (with_imports_UnionWithImportsVisitor) -> Any
         if not isinstance(visitor, with_imports_UnionWithImportsVisitor):
             raise ValueError('{} is not an instance of with_imports_UnionWithImportsVisitor'.format(visitor.__class__.__name__))
-        if self.type == 'string':
+        if self.string is not None:
             return visitor._string(self.string)
-        if self.type == 'imported':
+        if self.imported is not None:
             return visitor._imported(self.imported)
 
 

--- a/conjure-python-core/src/test/resources/types/expected/package_name/py.typed
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/py.typed
@@ -1,0 +1,1 @@
+# coding=utf-8

--- a/conjure-python-core/src/test/resources/types/expected/setup.py
+++ b/conjure-python-core/src/test/resources/types/expected/setup.py
@@ -7,6 +7,7 @@ from setuptools import (
 setup(
     name='package-name',
     version='0.0.0',
+    packageData='{"package-name": ["py.typed"]}',
     description='project description',
     packages=find_packages(),
     install_requires=[

--- a/conjure-python-verifier/python/test/client/conftest.py
+++ b/conjure-python-verifier/python/test/client/conftest.py
@@ -72,4 +72,4 @@ def confirm_service(config):
 @pytest.fixture(scope='module')
 def test_black_list():
     with open(path.dirname(__file__) + '/../../../resources/ignored_test_cases.yml') as blacklist_file:
-        return yaml.load(blacklist_file)['client']
+        return yaml.safe_load(blacklist_file)['client']


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
No types on the union `__init__` call mean that invalid values can be provided in unions without failing type check.
Lack of `py.typed` file means mypy will not inspect the sources of conjure modules for type annotations
## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Mark generated python packages as PEP-561 (type information) compliant; include type information in union constructors
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

