### PR TITLE
Fix syntax for packageData

### DIFF
--- a/changelog/@unreleased/pr-468.v2.yml
+++ b/changelog/@unreleased/pr-468.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fix syntax for packageData in setup.py, correctly including the py.typed
+    tag file in builds
+  links:
+  - https://github.com/palantir/conjure-python/pull/468

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/ConjurePythonGenerator.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/ConjurePythonGenerator.java
@@ -253,7 +253,7 @@ public final class ConjurePythonGenerator {
                 .putOptions("name", config.packageName().get())
                 .putOptions("version", config.packageVersion().get())
                 .putRawOptions(
-                        "packageData",
+                        "package_data",
                         String.format(
                                 "{\"%s\": [\"py.typed\"]}", config.packageName().get()))
                 .addInstallDependencies("requests", "typing")

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/ConjurePythonGenerator.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/ConjurePythonGenerator.java
@@ -252,7 +252,7 @@ public final class ConjurePythonGenerator {
                 .pythonPackage(rootPackage)
                 .putOptions("name", config.packageName().get())
                 .putOptions("version", config.packageVersion().get())
-                .putOptions(
+                .putRawOptions(
                         "packageData",
                         String.format(
                                 "{\"%s\": [\"py.typed\"]}", config.packageName().get()))

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonSetup.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonSetup.java
@@ -43,6 +43,11 @@ public interface PythonSetup extends PythonSnippet {
 
     Map<String, String> options();
 
+    /**
+     * Options that aren't a string value and as such shouldn't be wrapped in quotes.
+     */
+    Map<String, String> rawOptions();
+
     List<String> installDependencies();
 
     @Override
@@ -53,6 +58,9 @@ public interface PythonSetup extends PythonSnippet {
 
             options().forEach((key, value) -> {
                 poetWriter.writeIndentedLine("%s='%s',", key, value);
+            });
+            rawOptions().forEach((key, value) -> {
+                poetWriter.writeIndentedLine("%s=%s,", key, value);
             });
             poetWriter.writeIndentedLine("packages=find_packages(),");
 

--- a/conjure-python-core/src/test/resources/services/expected/setup.py
+++ b/conjure-python-core/src/test/resources/services/expected/setup.py
@@ -7,8 +7,8 @@ from setuptools import (
 setup(
     name='package-name',
     version='0.0.0',
-    packageData='{"package-name": ["py.typed"]}',
     description='project description',
+    packageData={"package-name": ["py.typed"]}
     packages=find_packages(),
     install_requires=[
         'requests',

--- a/conjure-python-core/src/test/resources/services/expected/setup.py
+++ b/conjure-python-core/src/test/resources/services/expected/setup.py
@@ -8,7 +8,7 @@ setup(
     name='package-name',
     version='0.0.0',
     description='project description',
-    packageData={"package-name": ["py.typed"]}
+    package_data={"package-name": ["py.typed"]},
     packages=find_packages(),
     install_requires=[
         'requests',

--- a/conjure-python-core/src/test/resources/types/expected/setup.py
+++ b/conjure-python-core/src/test/resources/types/expected/setup.py
@@ -7,8 +7,8 @@ from setuptools import (
 setup(
     name='package-name',
     version='0.0.0',
-    packageData='{"package-name": ["py.typed"]}',
     description='project description',
+    packageData={"package-name": ["py.typed"]}
     packages=find_packages(),
     install_requires=[
         'requests',

--- a/conjure-python-core/src/test/resources/types/expected/setup.py
+++ b/conjure-python-core/src/test/resources/types/expected/setup.py
@@ -8,7 +8,7 @@ setup(
     name='package-name',
     version='0.0.0',
     description='project description',
-    packageData={"package-name": ["py.typed"]}
+    package_data={"package-name": ["py.typed"]},
     packages=find_packages(),
     install_requires=[
         'requests',


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
No py.typed file in library dists

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fix syntax for packageData in setup.py, correctly including the py.typed tag file in builds
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

