### PR TITLE
Include py.typed for all packages

### DIFF
--- a/changelog/@unreleased/pr-471.v2.yml
+++ b/changelog/@unreleased/pr-471.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Include py.typed for all packages
+  links:
+  - https://github.com/palantir/conjure-python/pull/471

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/ConjurePythonGenerator.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/ConjurePythonGenerator.java
@@ -252,10 +252,7 @@ public final class ConjurePythonGenerator {
                 .pythonPackage(rootPackage)
                 .putOptions("name", config.packageName().get())
                 .putOptions("version", config.packageVersion().get())
-                .putRawOptions(
-                        "package_data",
-                        String.format(
-                                "{\"%s\": [\"py.typed\"]}", config.packageName().get()))
+                .putRawOptions("package_data", "{\"\": [\"py.typed\"]}")
                 .addInstallDependencies("requests", "typing")
                 .addInstallDependencies(String.format(
                         "conjure-python-client>=%s,<%s",

--- a/conjure-python-core/src/test/resources/services/expected/setup.py
+++ b/conjure-python-core/src/test/resources/services/expected/setup.py
@@ -8,7 +8,7 @@ setup(
     name='package-name',
     version='0.0.0',
     description='project description',
-    package_data={"package-name": ["py.typed"]},
+    package_data={"": ["py.typed"]},
     packages=find_packages(),
     install_requires=[
         'requests',

--- a/conjure-python-core/src/test/resources/types/expected/setup.py
+++ b/conjure-python-core/src/test/resources/types/expected/setup.py
@@ -8,7 +8,7 @@ setup(
     name='package-name',
     version='0.0.0',
     description='project description',
-    package_data={"package-name": ["py.typed"]},
+    package_data={"": ["py.typed"]},
     packages=find_packages(),
     install_requires=[
         'requests',


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Still no py.typed file for any packages with dashes in names, because those should have been underscores. All conjure packages have dashes.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Include py.typed for all packages
==COMMIT_MSG==


This time I've manually tested the setup.py change; for an internal product I replaced the generated `package_data` with `package_data={"": ["py.typed"]}` and verified the `py.typed` file is included in `python setup.py bdist`

I've also verified that if I manually add a `py.typed` file to `build/conda/env/lib/python3.6/site-packages/internal_package_name/py.typed` then the type declarations get picked up by mypy

Those two should hopefully mean this is the last PR
## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

