### PR TITLE
Fix: Don't import ABCMeta as we are not using it

### DIFF
--- a/changelog/@unreleased/pr-477.v2.yml
+++ b/changelog/@unreleased/pr-477.v2.yml
@@ -1,5 +1,5 @@
-type: improvement
-improvement:
-  description: Stop generating visitor base class for unions as we no longer support python 2
+type: fix
+fix:
+  description: Don't import ABCMeta as we are not using it
   links:
   - https://github.com/palantir/conjure-python/pull/476

--- a/changelog/@unreleased/pr-477.v2.yml
+++ b/changelog/@unreleased/pr-477.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Stop generating visitor base class for unions as we no longer support python 2
+  links:
+  - https://github.com/palantir/conjure-python/pull/476

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
@@ -35,6 +35,10 @@ public interface UnionSnippet extends PythonSnippet {
                     .addNamedImports(NamedImport.of("ConjureUnionType"), NamedImport.of("ConjureFieldDefinition"))
                     .build(),
             PythonImport.builder()
+                    .moduleSpecifier("abc")
+                    .addNamedImports(NamedImport.of("abstractmethod"))
+                    .build(),
+            PythonImport.builder()
                     .moduleSpecifier(ImportTypeVisitor.TYPING)
                     .addNamedImports(
                             NamedImport.of("Dict"),

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
@@ -35,10 +35,6 @@ public interface UnionSnippet extends PythonSnippet {
                     .addNamedImports(NamedImport.of("ConjureUnionType"), NamedImport.of("ConjureFieldDefinition"))
                     .build(),
             PythonImport.builder()
-                    .moduleSpecifier("abc")
-                    .addNamedImports(NamedImport.of("ABCMeta"), NamedImport.of("abstractmethod"))
-                    .build(),
-            PythonImport.builder()
                     .moduleSpecifier(ImportTypeVisitor.TYPING)
                     .addNamedImports(
                             NamedImport.of("Dict"),

--- a/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
@@ -1,4 +1,7 @@
 # coding=utf-8
+from abc import (
+    abstractmethod,
+)
 import builtins
 from conjure_python_client import (
     BinaryType,

--- a/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
@@ -1,8 +1,4 @@
 # coding=utf-8
-from abc import (
-    ABCMeta,
-    abstractmethod,
-)
 import builtins
 from conjure_python_client import (
     BinaryType,


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Visitor base class was only necessary for python 2 compat which has been dropped in 4.x
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

