### PR TITLE
Fix: import fewer things and avoid ignoring types 

### DIFF
--- a/changelog/@unreleased/pr-504.v2.yml
+++ b/changelog/@unreleased/pr-504.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Stop importing Type in generated code and type requests response object
+  links:
+  - https://github.com/palantir/conjure-python/pull/504

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/BeanSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/BeanSnippet.java
@@ -37,7 +37,7 @@ public interface BeanSnippet extends PythonSnippet {
             PythonImport.of("builtins"),
             PythonImport.builder()
                     .moduleSpecifier(ImportTypeVisitor.TYPING)
-                    .addNamedImports(NamedImport.of("Dict"), NamedImport.of("List"), NamedImport.of("Type"))
+                    .addNamedImports(NamedImport.of("Dict"), NamedImport.of("List"))
                     .build());
     ImmutableSet<String> PROTECTED_FIELDS = ImmutableSet.of("fields");
 
@@ -112,7 +112,7 @@ public interface BeanSnippet extends PythonSnippet {
                                                 PythonIdentifierSanitizer.sanitize(field.attributeName()),
                                                 field.myPyType());
                                         if (field.isOptional()) {
-                                            return String.format("%s=None", name);
+                                            return String.format("%s = None", name);
                                         }
                                         return name;
                                     })

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java
@@ -98,7 +98,7 @@ public interface PythonEndpointDefinition extends Emittable {
                                         String typedParam =
                                                 String.format("%s: %s", param.pythonParamName(), param.myPyType());
                                         if (param.isOptional()) {
-                                            return String.format("%s=None", typedParam);
+                                            return String.format("%s = None", typedParam);
                                         }
                                         return typedParam;
                                     })
@@ -192,7 +192,7 @@ public interface PythonEndpointDefinition extends Emittable {
             poetWriter.writeIndentedLine("_path = _path.format(**_path_params)");
 
             poetWriter.writeLine();
-            poetWriter.writeIndentedLine("_response = self._request( # type: ignore");
+            poetWriter.writeIndentedLine("_response: Response = self._request(");
             poetWriter.increaseIndent();
             poetWriter.writeIndentedLine("'%s',", httpMethod());
             poetWriter.writeIndentedLine("self._uri + _path,");

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonService.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonService.java
@@ -34,9 +34,13 @@ public interface PythonService extends PythonSnippet {
                             NamedImport.of("ConjureDecoder"))
                     .build(),
             PythonImport.builder()
+                    .moduleSpecifier("requests.adapters")
+                    .addNamedImports(NamedImport.of("Response"))
+                    .build(),
+            PythonImport.builder()
                     .moduleSpecifier(ImportTypeVisitor.TYPING)
                     // Used by Endpoints
-                    .addNamedImports(NamedImport.of("Dict"), NamedImport.of("Any"), NamedImport.of("Type"))
+                    .addNamedImports(NamedImport.of("Dict"), NamedImport.of("Any"))
                     .build());
 
     @Override

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
@@ -40,11 +40,7 @@ public interface UnionSnippet extends PythonSnippet {
                     .build(),
             PythonImport.builder()
                     .moduleSpecifier(ImportTypeVisitor.TYPING)
-                    .addNamedImports(
-                            NamedImport.of("Dict"),
-                            NamedImport.of("Any"),
-                            NamedImport.of("Optional"),
-                            NamedImport.of("Type"))
+                    .addNamedImports(NamedImport.of("Dict"), NamedImport.of("Any"), NamedImport.of("Optional"))
                     .build(),
             PythonImport.of("builtins"));
     ImmutableSet<String> PROTECTED_FIELDS = ImmutableSet.of("options");

--- a/conjure-python-core/src/test/java/com/palantir/conjure/python/ConjureSubfolderRunner.java
+++ b/conjure-python-core/src/test/java/com/palantir/conjure/python/ConjureSubfolderRunner.java
@@ -54,7 +54,7 @@ public final class ConjureSubfolderRunner extends ParentRunner<Path> {
     public @interface ParentFolder {
         /** Parent folder to list. */
         String value();
-        /** Whether tests should be executed indepenently on a CachedThreadPool. */
+        /** Whether tests should be executed independently on a CachedThreadPool. */
         boolean parallel() default false;
     }
 

--- a/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
@@ -9,13 +9,15 @@ from conjure_python_client import (
     OptionalTypeWrapper,
     Service,
 )
+from requests.adapters import (
+    Response,
+)
 from typing import (
     Any,
     Dict,
     List,
     Optional,
     Set,
-    Type,
 )
 
 class another_TestService(Service):
@@ -44,7 +46,7 @@ class another_TestService(Service):
         _path = '/catalog/fileSystems'
         _path = _path.format(**_path_params)
 
-        _response = self._request( # type: ignore
+        _response: Response = self._request(
             'GET',
             self._uri + _path,
             params=_params,
@@ -74,7 +76,7 @@ class another_TestService(Service):
         _path = '/catalog/datasets'
         _path = _path.format(**_path_params)
 
-        _response = self._request( # type: ignore
+        _response: Response = self._request(
             'POST',
             self._uri + _path,
             params=_params,
@@ -103,7 +105,7 @@ class another_TestService(Service):
         _path = '/catalog/datasets/{datasetRid}'
         _path = _path.format(**_path_params)
 
-        _response = self._request( # type: ignore
+        _response: Response = self._request(
             'GET',
             self._uri + _path,
             params=_params,
@@ -132,7 +134,7 @@ class another_TestService(Service):
         _path = '/catalog/datasets/{datasetRid}/raw'
         _path = _path.format(**_path_params)
 
-        _response = self._request( # type: ignore
+        _response: Response = self._request(
             'GET',
             self._uri + _path,
             params=_params,
@@ -163,7 +165,7 @@ class another_TestService(Service):
         _path = '/catalog/datasets/{datasetRid}/raw-maybe'
         _path = _path.format(**_path_params)
 
-        _response = self._request( # type: ignore
+        _response: Response = self._request(
             'GET',
             self._uri + _path,
             params=_params,
@@ -192,7 +194,7 @@ class another_TestService(Service):
         _path = '/catalog/datasets/upload-raw'
         _path = _path.format(**_path_params)
 
-        _response = self._request( # type: ignore
+        _response: Response = self._request(
             'POST',
             self._uri + _path,
             params=_params,
@@ -201,7 +203,7 @@ class another_TestService(Service):
 
         return
 
-    def get_branches(self, auth_header: str, dataset_rid: str, message: Optional[str]=None, page_size: Optional[int]=None) -> List[str]:
+    def get_branches(self, auth_header: str, dataset_rid: str, message: Optional[str] = None, page_size: Optional[int] = None) -> List[str]:
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
@@ -222,7 +224,7 @@ class another_TestService(Service):
         _path = '/catalog/datasets/{datasetRid}/branches'
         _path = _path.format(**_path_params)
 
-        _response = self._request( # type: ignore
+        _response: Response = self._request(
             'GET',
             self._uri + _path,
             params=_params,
@@ -254,7 +256,7 @@ class another_TestService(Service):
         _path = '/catalog/datasets/{datasetRid}/branchesDeprecated'
         _path = _path.format(**_path_params)
 
-        _response = self._request( # type: ignore
+        _response: Response = self._request(
             'GET',
             self._uri + _path,
             params=_params,
@@ -284,7 +286,7 @@ class another_TestService(Service):
         _path = '/catalog/datasets/{datasetRid}/branches/{branch}/resolve'
         _path = _path.format(**_path_params)
 
-        _response = self._request( # type: ignore
+        _response: Response = self._request(
             'GET',
             self._uri + _path,
             params=_params,
@@ -313,7 +315,7 @@ class another_TestService(Service):
         _path = '/catalog/datasets/{datasetRid}/testParam'
         _path = _path.format(**_path_params)
 
-        _response = self._request( # type: ignore
+        _response: Response = self._request(
             'GET',
             self._uri + _path,
             params=_params,
@@ -343,7 +345,7 @@ class another_TestService(Service):
         _path = '/catalog/test-query-params'
         _path = _path.format(**_path_params)
 
-        _response = self._request( # type: ignore
+        _response: Response = self._request(
             'GET',
             self._uri + _path,
             params=_params,
@@ -371,7 +373,7 @@ class another_TestService(Service):
         _path = '/catalog/boolean'
         _path = _path.format(**_path_params)
 
-        _response = self._request( # type: ignore
+        _response: Response = self._request(
             'GET',
             self._uri + _path,
             params=_params,
@@ -399,7 +401,7 @@ class another_TestService(Service):
         _path = '/catalog/double'
         _path = _path.format(**_path_params)
 
-        _response = self._request( # type: ignore
+        _response: Response = self._request(
             'GET',
             self._uri + _path,
             params=_params,
@@ -427,7 +429,7 @@ class another_TestService(Service):
         _path = '/catalog/integer'
         _path = _path.format(**_path_params)
 
-        _response = self._request( # type: ignore
+        _response: Response = self._request(
             'GET',
             self._uri + _path,
             params=_params,

--- a/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
@@ -14,13 +14,15 @@ from conjure_python_client import (
     OptionalTypeWrapper,
     Service,
 )
+from requests.adapters import (
+    Response,
+)
 from typing import (
     Any,
     Dict,
     List,
     Optional,
     Set,
-    Type,
 )
 
 class another_TestService(Service):
@@ -49,7 +51,7 @@ class another_TestService(Service):
         _path = '/catalog/fileSystems'
         _path = _path.format(**_path_params)
 
-        _response = self._request( # type: ignore
+        _response: Response = self._request(
             'GET',
             self._uri + _path,
             params=_params,
@@ -79,7 +81,7 @@ class another_TestService(Service):
         _path = '/catalog/datasets'
         _path = _path.format(**_path_params)
 
-        _response = self._request( # type: ignore
+        _response: Response = self._request(
             'POST',
             self._uri + _path,
             params=_params,
@@ -108,7 +110,7 @@ class another_TestService(Service):
         _path = '/catalog/datasets/{datasetRid}'
         _path = _path.format(**_path_params)
 
-        _response = self._request( # type: ignore
+        _response: Response = self._request(
             'GET',
             self._uri + _path,
             params=_params,
@@ -137,7 +139,7 @@ class another_TestService(Service):
         _path = '/catalog/datasets/{datasetRid}/raw'
         _path = _path.format(**_path_params)
 
-        _response = self._request( # type: ignore
+        _response: Response = self._request(
             'GET',
             self._uri + _path,
             params=_params,
@@ -168,7 +170,7 @@ class another_TestService(Service):
         _path = '/catalog/datasets/{datasetRid}/raw-maybe'
         _path = _path.format(**_path_params)
 
-        _response = self._request( # type: ignore
+        _response: Response = self._request(
             'GET',
             self._uri + _path,
             params=_params,
@@ -197,7 +199,7 @@ class another_TestService(Service):
         _path = '/catalog/datasets/upload-raw'
         _path = _path.format(**_path_params)
 
-        _response = self._request( # type: ignore
+        _response: Response = self._request(
             'POST',
             self._uri + _path,
             params=_params,
@@ -206,7 +208,7 @@ class another_TestService(Service):
 
         return
 
-    def get_branches(self, auth_header: str, dataset_rid: str, message: Optional[str]=None, page_size: Optional[int]=None) -> List[str]:
+    def get_branches(self, auth_header: str, dataset_rid: str, message: Optional[str] = None, page_size: Optional[int] = None) -> List[str]:
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
@@ -227,7 +229,7 @@ class another_TestService(Service):
         _path = '/catalog/datasets/{datasetRid}/branches'
         _path = _path.format(**_path_params)
 
-        _response = self._request( # type: ignore
+        _response: Response = self._request(
             'GET',
             self._uri + _path,
             params=_params,
@@ -259,7 +261,7 @@ class another_TestService(Service):
         _path = '/catalog/datasets/{datasetRid}/branchesDeprecated'
         _path = _path.format(**_path_params)
 
-        _response = self._request( # type: ignore
+        _response: Response = self._request(
             'GET',
             self._uri + _path,
             params=_params,
@@ -289,7 +291,7 @@ class another_TestService(Service):
         _path = '/catalog/datasets/{datasetRid}/branches/{branch}/resolve'
         _path = _path.format(**_path_params)
 
-        _response = self._request( # type: ignore
+        _response: Response = self._request(
             'GET',
             self._uri + _path,
             params=_params,
@@ -318,7 +320,7 @@ class another_TestService(Service):
         _path = '/catalog/datasets/{datasetRid}/testParam'
         _path = _path.format(**_path_params)
 
-        _response = self._request( # type: ignore
+        _response: Response = self._request(
             'GET',
             self._uri + _path,
             params=_params,
@@ -348,7 +350,7 @@ class another_TestService(Service):
         _path = '/catalog/test-query-params'
         _path = _path.format(**_path_params)
 
-        _response = self._request( # type: ignore
+        _response: Response = self._request(
             'GET',
             self._uri + _path,
             params=_params,
@@ -376,7 +378,7 @@ class another_TestService(Service):
         _path = '/catalog/boolean'
         _path = _path.format(**_path_params)
 
-        _response = self._request( # type: ignore
+        _response: Response = self._request(
             'GET',
             self._uri + _path,
             params=_params,
@@ -404,7 +406,7 @@ class another_TestService(Service):
         _path = '/catalog/double'
         _path = _path.format(**_path_params)
 
-        _response = self._request( # type: ignore
+        _response: Response = self._request(
             'GET',
             self._uri + _path,
             params=_params,
@@ -432,7 +434,7 @@ class another_TestService(Service):
         _path = '/catalog/integer'
         _path = _path.format(**_path_params)
 
-        _response = self._request( # type: ignore
+        _response: Response = self._request(
             'GET',
             self._uri + _path,
             params=_params,
@@ -468,7 +470,7 @@ class nested_deeply_nested_service_DeeplyNestedService(Service):
         _path = '/catalog/testEndpoint'
         _path = _path.format(**_path_params)
 
-        _response = self._request( # type: ignore
+        _response: Response = self._request(
             'POST',
             self._uri + _path,
             params=_params,
@@ -504,7 +506,7 @@ class nested_service2_SimpleNestedService2(Service):
         _path = '/catalog/testEndpoint'
         _path = _path.format(**_path_params)
 
-        _response = self._request( # type: ignore
+        _response: Response = self._request(
             'POST',
             self._uri + _path,
             params=_params,
@@ -540,7 +542,7 @@ class nested_service_SimpleNestedService(Service):
         _path = '/catalog/testEndpoint'
         _path = _path.format(**_path_params)
 
-        _response = self._request( # type: ignore
+        _response: Response = self._request(
             'POST',
             self._uri + _path,
             params=_params,
@@ -986,7 +988,7 @@ class product_ManyFieldExample(ConjureBeanType):
 
     __slots__: List[str] = ['_string', '_integer', '_double_value', '_optional_item', '_items', '_set', '_map', '_alias']
 
-    def __init__(self, alias: str, double_value: float, integer: int, items: List[str], map: Dict[str, str], set: List[str], string: str, optional_item: Optional[str]=None) -> None:
+    def __init__(self, alias: str, double_value: float, integer: int, items: List[str], map: Dict[str, str], set: List[str], string: str, optional_item: Optional[str] = None) -> None:
         self._string = string
         self._integer = integer
         self._double_value = double_value
@@ -1091,7 +1093,7 @@ class product_OptionalExample(ConjureBeanType):
 
     __slots__: List[str] = ['_item']
 
-    def __init__(self, item: Optional[str]=None) -> None:
+    def __init__(self, item: Optional[str] = None) -> None:
         self._item = item
 
     @builtins.property
@@ -1168,7 +1170,7 @@ class product_PrimitiveOptionalsExample(ConjureBeanType):
 
     __slots__: List[str] = ['_num', '_bool_', '_integer', '_safelong', '_rid', '_bearertoken', '_uuid']
 
-    def __init__(self, bearertoken: Optional[str]=None, bool_: Optional[bool]=None, integer: Optional[int]=None, num: Optional[float]=None, rid: Optional[str]=None, safelong: Optional[int]=None, uuid: Optional[str]=None) -> None:
+    def __init__(self, bearertoken: Optional[str] = None, bool_: Optional[bool] = None, integer: Optional[int] = None, num: Optional[float] = None, rid: Optional[str] = None, safelong: Optional[int] = None, uuid: Optional[str] = None) -> None:
         self._num = num
         self._bool_ = bool_
         self._integer = integer
@@ -1221,7 +1223,7 @@ class product_RecursiveObjectExample(ConjureBeanType):
 
     __slots__: List[str] = ['_recursive_field']
 
-    def __init__(self, recursive_field: Optional["product_RecursiveObjectExample"]=None) -> None:
+    def __init__(self, recursive_field: Optional["product_RecursiveObjectExample"] = None) -> None:
         self._recursive_field = recursive_field
 
     @builtins.property
@@ -1679,7 +1681,7 @@ class with_imports_ImportService(Service):
         _path = '/catalog/testEndpoint'
         _path = _path.format(**_path_params)
 
-        _response = self._request( # type: ignore
+        _response: Response = self._request(
             'POST',
             self._uri + _path,
             params=_params,


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Stop importing Type in generated code and type requests response object
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

