### PR TITLE
Fix: Correctly serialize binary request bodies

### DIFF
--- a/changelog/@unreleased/pr-528.v2.yml
+++ b/changelog/@unreleased/pr-528.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Binary request data are sent as raw data and not as binary
+  links:
+  - https://github.com/palantir/conjure-python/pull/528

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java
@@ -174,10 +174,16 @@ public interface PythonEndpointDefinition extends Emittable {
             poetWriter.writeIndentedLine("}");
 
             if (bodyParam.isPresent()) {
-                poetWriter.writeLine();
-                poetWriter.writeIndentedLine(
-                        "_json: Any = ConjureEncoder().default(%s)",
-                        bodyParam.get().pythonParamName());
+                if (!isRequestBinary()) {
+                    poetWriter.writeLine();
+                    poetWriter.writeIndentedLine(
+                            "_json: Any = ConjureEncoder().default(%s)",
+                            bodyParam.get().pythonParamName());
+                } else {
+                    poetWriter.writeLine();
+                    poetWriter.writeIndentedLine(
+                            "_data: Any = %s", bodyParam.get().pythonParamName());
+                }
             } else {
                 poetWriter.writeLine();
                 poetWriter.writeIndentedLine("_json: Any = None");
@@ -187,7 +193,7 @@ public interface PythonEndpointDefinition extends Emittable {
             poetWriter.writeLine();
 
             HttpPath fullPath = httpPath();
-            String fixedPath = fullPath.toString().replaceAll("\\{(.*):[^}]*\\}", "{$1}");
+            String fixedPath = fullPath.toString().replaceAll("\\{(.*):[^}]*}", "{$1}");
             poetWriter.writeIndentedLine("_path = '%s'", fixedPath);
             poetWriter.writeIndentedLine("_path = _path.format(**_path_params)");
 
@@ -201,7 +207,11 @@ public interface PythonEndpointDefinition extends Emittable {
             if (isResponseBinary()) {
                 poetWriter.writeIndentedLine("stream=True,");
             }
-            poetWriter.writeIndentedLine("json=_json)");
+            if (!isRequestBinary()) {
+                poetWriter.writeIndentedLine("json=_json)");
+            } else {
+                poetWriter.writeIndentedLine("data=_data)");
+            }
             poetWriter.decreaseIndent();
 
             poetWriter.writeLine();

--- a/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
@@ -187,7 +187,7 @@ class another_TestService(Service):
         _path_params: Dict[str, Any] = {
         }
 
-        _json: Any = ConjureEncoder().default(input)
+        _data: Any = input
 
         _path = '/catalog/datasets/upload-raw'
         _path = _path.format(**_path_params)
@@ -197,7 +197,7 @@ class another_TestService(Service):
             self._uri + _path,
             params=_params,
             headers=_headers,
-            json=_json)
+            data=_data)
 
         return
 

--- a/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
@@ -192,7 +192,7 @@ class another_TestService(Service):
         _path_params: Dict[str, Any] = {
         }
 
-        _json: Any = ConjureEncoder().default(input)
+        _data: Any = input
 
         _path = '/catalog/datasets/upload-raw'
         _path = _path.format(**_path_params)
@@ -202,7 +202,7 @@ class another_TestService(Service):
             self._uri + _path,
             params=_params,
             headers=_headers,
-            json=_json)
+            data=_data)
 
         return
 


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Binary request data are sent as raw data and not as json
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

