### PR TITLE
Encode path parameters in endpoint definitions

### DIFF
--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java
@@ -168,7 +168,8 @@ public interface PythonEndpointDefinition extends Emittable {
             paramsWithHeader.stream()
                     .filter(param -> param.paramType().accept(ParameterTypeVisitor.IS_PATH))
                     .forEach(param -> {
-                        poetWriter.writeIndentedLine("'%s': %s,", param.paramName(), param.pythonParamName());
+                        poetWriter.writeIndentedLine(
+                                "'%s': quote(%s, safe=''),", param.paramName(), param.pythonParamName());
                     });
             poetWriter.decreaseIndent();
             poetWriter.writeIndentedLine("}");

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java
@@ -162,14 +162,14 @@ public interface PythonEndpointDefinition extends Emittable {
 
             // path params
             poetWriter.writeLine();
-            poetWriter.writeIndentedLine("_path_params: Dict[str, Any] = {");
+            poetWriter.writeIndentedLine("_path_params: Dict[str, str] = {");
             poetWriter.increaseIndent();
             // TODO(qchen): no need for param name twice?
             paramsWithHeader.stream()
                     .filter(param -> param.paramType().accept(ParameterTypeVisitor.IS_PATH))
                     .forEach(param -> {
                         poetWriter.writeIndentedLine(
-                                "'%s': quote(%s, safe=''),", param.paramName(), param.pythonParamName());
+                                "'%s': quote(str(%s), safe=''),", param.paramName(), param.pythonParamName());
                     });
             poetWriter.decreaseIndent();
             poetWriter.writeIndentedLine("}");

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonService.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonService.java
@@ -38,7 +38,7 @@ public interface PythonService extends PythonSnippet {
                     .addNamedImports(NamedImport.of("Response"))
                     .build(),
             PythonImport.builder()
-                    .moduleSpecifier("requests.utils")
+                    .moduleSpecifier("urllib.parse")
                     .addNamedImports(NamedImport.of("quote"))
                     .build(),
             PythonImport.builder()

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonService.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonService.java
@@ -38,6 +38,10 @@ public interface PythonService extends PythonSnippet {
                     .addNamedImports(NamedImport.of("Response"))
                     .build(),
             PythonImport.builder()
+                    .moduleSpecifier("requests.utils")
+                    .addNamedImports(NamedImport.of("quote"))
+                    .build(),
+            PythonImport.builder()
                     .moduleSpecifier(ImportTypeVisitor.TYPING)
                     // Used by Endpoints
                     .addNamedImports(NamedImport.of("Dict"), NamedImport.of("Any"))

--- a/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
@@ -41,7 +41,7 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
+        _path_params: Dict[str, str] = {
         }
 
         _json: Any = None
@@ -71,7 +71,7 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
+        _path_params: Dict[str, str] = {
         }
 
         _json: Any = ConjureEncoder().default(request)
@@ -99,8 +99,8 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
-            'datasetRid': quote(dataset_rid, safe=''),
+        _path_params: Dict[str, str] = {
+            'datasetRid': quote(str(dataset_rid), safe=''),
         }
 
         _json: Any = None
@@ -128,8 +128,8 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
-            'datasetRid': quote(dataset_rid, safe=''),
+        _path_params: Dict[str, str] = {
+            'datasetRid': quote(str(dataset_rid), safe=''),
         }
 
         _json: Any = None
@@ -159,8 +159,8 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
-            'datasetRid': quote(dataset_rid, safe=''),
+        _path_params: Dict[str, str] = {
+            'datasetRid': quote(str(dataset_rid), safe=''),
         }
 
         _json: Any = None
@@ -189,7 +189,7 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
+        _path_params: Dict[str, str] = {
         }
 
         _data: Any = input
@@ -218,8 +218,8 @@ class another_TestService(Service):
             'pageSize': page_size,
         }
 
-        _path_params: Dict[str, Any] = {
-            'datasetRid': quote(dataset_rid, safe=''),
+        _path_params: Dict[str, str] = {
+            'datasetRid': quote(str(dataset_rid), safe=''),
         }
 
         _json: Any = None
@@ -250,8 +250,8 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
-            'datasetRid': quote(dataset_rid, safe=''),
+        _path_params: Dict[str, str] = {
+            'datasetRid': quote(str(dataset_rid), safe=''),
         }
 
         _json: Any = None
@@ -279,9 +279,9 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
-            'datasetRid': quote(dataset_rid, safe=''),
-            'branch': quote(branch, safe=''),
+        _path_params: Dict[str, str] = {
+            'datasetRid': quote(str(dataset_rid), safe=''),
+            'branch': quote(str(branch), safe=''),
         }
 
         _json: Any = None
@@ -309,8 +309,8 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
-            'datasetRid': quote(dataset_rid, safe=''),
+        _path_params: Dict[str, str] = {
+            'datasetRid': quote(str(dataset_rid), safe=''),
         }
 
         _json: Any = None
@@ -340,7 +340,7 @@ class another_TestService(Service):
             'implicit': implicit,
         }
 
-        _path_params: Dict[str, Any] = {
+        _path_params: Dict[str, str] = {
         }
 
         _json: Any = None
@@ -368,7 +368,7 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
+        _path_params: Dict[str, str] = {
         }
 
         _json: Any = None
@@ -396,7 +396,7 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
+        _path_params: Dict[str, str] = {
         }
 
         _json: Any = None
@@ -424,7 +424,7 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
+        _path_params: Dict[str, str] = {
         }
 
         _json: Any = None

--- a/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
@@ -12,15 +12,15 @@ from conjure_python_client import (
 from requests.adapters import (
     Response,
 )
-from requests.utils import (
-    quote,
-)
 from typing import (
     Any,
     Dict,
     List,
     Optional,
     Set,
+)
+from urllib.parse import (
+    quote,
 )
 
 class another_TestService(Service):

--- a/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
@@ -12,6 +12,9 @@ from conjure_python_client import (
 from requests.adapters import (
     Response,
 )
+from requests.utils import (
+    quote,
+)
 from typing import (
     Any,
     Dict,
@@ -97,7 +100,7 @@ class another_TestService(Service):
         }
 
         _path_params: Dict[str, Any] = {
-            'datasetRid': dataset_rid,
+            'datasetRid': quote(dataset_rid, safe=''),
         }
 
         _json: Any = None
@@ -126,7 +129,7 @@ class another_TestService(Service):
         }
 
         _path_params: Dict[str, Any] = {
-            'datasetRid': dataset_rid,
+            'datasetRid': quote(dataset_rid, safe=''),
         }
 
         _json: Any = None
@@ -157,7 +160,7 @@ class another_TestService(Service):
         }
 
         _path_params: Dict[str, Any] = {
-            'datasetRid': dataset_rid,
+            'datasetRid': quote(dataset_rid, safe=''),
         }
 
         _json: Any = None
@@ -216,7 +219,7 @@ class another_TestService(Service):
         }
 
         _path_params: Dict[str, Any] = {
-            'datasetRid': dataset_rid,
+            'datasetRid': quote(dataset_rid, safe=''),
         }
 
         _json: Any = None
@@ -248,7 +251,7 @@ class another_TestService(Service):
         }
 
         _path_params: Dict[str, Any] = {
-            'datasetRid': dataset_rid,
+            'datasetRid': quote(dataset_rid, safe=''),
         }
 
         _json: Any = None
@@ -277,8 +280,8 @@ class another_TestService(Service):
         }
 
         _path_params: Dict[str, Any] = {
-            'datasetRid': dataset_rid,
-            'branch': branch,
+            'datasetRid': quote(dataset_rid, safe=''),
+            'branch': quote(branch, safe=''),
         }
 
         _json: Any = None
@@ -307,7 +310,7 @@ class another_TestService(Service):
         }
 
         _path_params: Dict[str, Any] = {
-            'datasetRid': dataset_rid,
+            'datasetRid': quote(dataset_rid, safe=''),
         }
 
         _json: Any = None

--- a/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
@@ -17,15 +17,15 @@ from conjure_python_client import (
 from requests.adapters import (
     Response,
 )
-from requests.utils import (
-    quote,
-)
 from typing import (
     Any,
     Dict,
     List,
     Optional,
     Set,
+)
+from urllib.parse import (
+    quote,
 )
 
 class another_TestService(Service):

--- a/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
@@ -46,7 +46,7 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
+        _path_params: Dict[str, str] = {
         }
 
         _json: Any = None
@@ -76,7 +76,7 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
+        _path_params: Dict[str, str] = {
         }
 
         _json: Any = ConjureEncoder().default(request)
@@ -104,8 +104,8 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
-            'datasetRid': quote(dataset_rid, safe=''),
+        _path_params: Dict[str, str] = {
+            'datasetRid': quote(str(dataset_rid), safe=''),
         }
 
         _json: Any = None
@@ -133,8 +133,8 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
-            'datasetRid': quote(dataset_rid, safe=''),
+        _path_params: Dict[str, str] = {
+            'datasetRid': quote(str(dataset_rid), safe=''),
         }
 
         _json: Any = None
@@ -164,8 +164,8 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
-            'datasetRid': quote(dataset_rid, safe=''),
+        _path_params: Dict[str, str] = {
+            'datasetRid': quote(str(dataset_rid), safe=''),
         }
 
         _json: Any = None
@@ -194,7 +194,7 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
+        _path_params: Dict[str, str] = {
         }
 
         _data: Any = input
@@ -223,8 +223,8 @@ class another_TestService(Service):
             'pageSize': page_size,
         }
 
-        _path_params: Dict[str, Any] = {
-            'datasetRid': quote(dataset_rid, safe=''),
+        _path_params: Dict[str, str] = {
+            'datasetRid': quote(str(dataset_rid), safe=''),
         }
 
         _json: Any = None
@@ -255,8 +255,8 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
-            'datasetRid': quote(dataset_rid, safe=''),
+        _path_params: Dict[str, str] = {
+            'datasetRid': quote(str(dataset_rid), safe=''),
         }
 
         _json: Any = None
@@ -284,9 +284,9 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
-            'datasetRid': quote(dataset_rid, safe=''),
-            'branch': quote(branch, safe=''),
+        _path_params: Dict[str, str] = {
+            'datasetRid': quote(str(dataset_rid), safe=''),
+            'branch': quote(str(branch), safe=''),
         }
 
         _json: Any = None
@@ -314,8 +314,8 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
-            'datasetRid': quote(dataset_rid, safe=''),
+        _path_params: Dict[str, str] = {
+            'datasetRid': quote(str(dataset_rid), safe=''),
         }
 
         _json: Any = None
@@ -345,7 +345,7 @@ class another_TestService(Service):
             'implicit': implicit,
         }
 
-        _path_params: Dict[str, Any] = {
+        _path_params: Dict[str, str] = {
         }
 
         _json: Any = None
@@ -373,7 +373,7 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
+        _path_params: Dict[str, str] = {
         }
 
         _json: Any = None
@@ -401,7 +401,7 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
+        _path_params: Dict[str, str] = {
         }
 
         _json: Any = None
@@ -429,7 +429,7 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
+        _path_params: Dict[str, str] = {
         }
 
         _json: Any = None
@@ -465,7 +465,7 @@ class nested_deeply_nested_service_DeeplyNestedService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
+        _path_params: Dict[str, str] = {
         }
 
         _json: Any = ConjureEncoder().default(string)
@@ -501,7 +501,7 @@ class nested_service2_SimpleNestedService2(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
+        _path_params: Dict[str, str] = {
         }
 
         _json: Any = ConjureEncoder().default(string)
@@ -537,7 +537,7 @@ class nested_service_SimpleNestedService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
+        _path_params: Dict[str, str] = {
         }
 
         _json: Any = ConjureEncoder().default(string)
@@ -1676,7 +1676,7 @@ class with_imports_ImportService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
+        _path_params: Dict[str, str] = {
         }
 
         _json: Any = ConjureEncoder().default(imported_string)

--- a/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
@@ -17,6 +17,9 @@ from conjure_python_client import (
 from requests.adapters import (
     Response,
 )
+from requests.utils import (
+    quote,
+)
 from typing import (
     Any,
     Dict,
@@ -102,7 +105,7 @@ class another_TestService(Service):
         }
 
         _path_params: Dict[str, Any] = {
-            'datasetRid': dataset_rid,
+            'datasetRid': quote(dataset_rid, safe=''),
         }
 
         _json: Any = None
@@ -131,7 +134,7 @@ class another_TestService(Service):
         }
 
         _path_params: Dict[str, Any] = {
-            'datasetRid': dataset_rid,
+            'datasetRid': quote(dataset_rid, safe=''),
         }
 
         _json: Any = None
@@ -162,7 +165,7 @@ class another_TestService(Service):
         }
 
         _path_params: Dict[str, Any] = {
-            'datasetRid': dataset_rid,
+            'datasetRid': quote(dataset_rid, safe=''),
         }
 
         _json: Any = None
@@ -221,7 +224,7 @@ class another_TestService(Service):
         }
 
         _path_params: Dict[str, Any] = {
-            'datasetRid': dataset_rid,
+            'datasetRid': quote(dataset_rid, safe=''),
         }
 
         _json: Any = None
@@ -253,7 +256,7 @@ class another_TestService(Service):
         }
 
         _path_params: Dict[str, Any] = {
-            'datasetRid': dataset_rid,
+            'datasetRid': quote(dataset_rid, safe=''),
         }
 
         _json: Any = None
@@ -282,8 +285,8 @@ class another_TestService(Service):
         }
 
         _path_params: Dict[str, Any] = {
-            'datasetRid': dataset_rid,
-            'branch': branch,
+            'datasetRid': quote(dataset_rid, safe=''),
+            'branch': quote(branch, safe=''),
         }
 
         _json: Any = None
@@ -312,7 +315,7 @@ class another_TestService(Service):
         }
 
         _path_params: Dict[str, Any] = {
-            'datasetRid': dataset_rid,
+            'datasetRid': quote(dataset_rid, safe=''),
         }
 
         _json: Any = None


### PR DESCRIPTION
## Before this PR
Fixes https://github.com/palantir/conjure-python/issues/595

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Path parameters are url encoded per conjure specification
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

