### PR TITLE
Default values for list/set query&header params

### DIFF
--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java
@@ -95,8 +95,12 @@ public interface PythonEndpointDefinition extends Emittable {
                             .join(paramsWithHeader.stream()
                                     .sorted(new PythonEndpointParamComparator())
                                     .map(param -> {
-                                        String typedParam =
-                                                String.format("%s: %s", param.pythonParamName(), param.myPyType());
+                                        String defaultValuePart = param.defaultValue()
+                                                .map(value -> "=" + value)
+                                                .orElse("");
+                                        String typedParam = String.format(
+                                                "%s: %s%s",
+                                                param.pythonParamName(), param.myPyType(), defaultValuePart);
                                         if (param.isOptional()) {
                                             return String.format("%s = None", typedParam);
                                         }
@@ -252,6 +256,8 @@ public interface PythonEndpointDefinition extends Emittable {
         String pythonParamName();
 
         String myPyType();
+
+        Optional<String> defaultValue();
 
         ParameterType paramType();
 

--- a/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
@@ -325,7 +325,7 @@ class another_TestService(Service):
         _decoder = ConjureDecoder()
         return None if _response.status_code == 204 else _decoder.decode(_response.json(), OptionalTypeWrapper[str])
 
-    def test_query_params(self, auth_header: str, implicit: str, something: str) -> int:
+    def test_query_params(self, auth_header: str, implicit: str, list: List[int]=[], set: List[int]=[], something: str) -> int:
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
@@ -335,6 +335,8 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
             'different': something,
             'implicit': implicit,
+            'list': list,
+            'set': set,
         }
 
         _path_params: Dict[str, Any] = {

--- a/conjure-python-core/src/test/resources/types/example-service.yml
+++ b/conjure-python-core/src/test/resources/types/example-service.yml
@@ -178,6 +178,12 @@ services:
           implicit:
             type: rid
             param-type: query
+          list:
+            type: list<integer>
+            param-type: query
+          set:
+            type: set<integer>
+            param-type: query
         returns: integer
 
       testBoolean:

--- a/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
@@ -330,7 +330,7 @@ class another_TestService(Service):
         _decoder = ConjureDecoder()
         return None if _response.status_code == 204 else _decoder.decode(_response.json(), OptionalTypeWrapper[str])
 
-    def test_query_params(self, auth_header: str, implicit: str, something: str) -> int:
+    def test_query_params(self, auth_header: str, implicit: str, list: List[int]=[], set: List[int]=[], something: str) -> int:
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
@@ -340,6 +340,8 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
             'different': something,
             'implicit': implicit,
+            'list': list,
+            'set': set,
         }
 
         _path_params: Dict[str, Any] = {


### PR DESCRIPTION
Handle adding default query/header list/set parameters without breaking function callers

Fix https://github.com/palantir/conjure-python/issues/615