### PR TITLE
Default values for list/set query&header params

### DIFF
--- a/changelog/@unreleased/pr-618.v2.yml
+++ b/changelog/@unreleased/pr-618.v2.yml
@@ -2,9 +2,5 @@ type: improvement
 improvement:
   description: |-
     Default values for list/set query&header params
-
-    Handle adding default query/header list/set parameters without breaking function callers
-
-    Fix https://github.com/palantir/conjure-python/issues/615
   links:
   - https://github.com/palantir/conjure-python/pull/618

--- a/changelog/@unreleased/pr-618.v2.yml
+++ b/changelog/@unreleased/pr-618.v2.yml
@@ -1,0 +1,10 @@
+type: improvement
+improvement:
+  description: |-
+    Default values for list/set query&header params
+
+    Handle adding default query/header list/set parameters without breaking function callers
+
+    Fix https://github.com/palantir/conjure-python/issues/615
+  links:
+  - https://github.com/palantir/conjure-python/pull/618

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/client/ClientGenerator.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/client/ClientGenerator.java
@@ -149,7 +149,7 @@ public final class ClientGenerator {
     }
 
     private static Optional<String> getDefaultValue(ArgumentDefinition argumentDefinition) {
-        Optional<String> emptyValue = argumentDefinition.getType().accept(new Visitor<Optional<String>>() {
+        Optional<String> emptyValue = argumentDefinition.getType().accept(new Visitor<>() {
             @Override
             public Optional<String> visitPrimitive(PrimitiveType _value) {
                 return Optional.empty();

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/client/ClientGenerator.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/client/ClientGenerator.java
@@ -162,12 +162,12 @@ public final class ClientGenerator {
 
             @Override
             public Optional<String> visitList(ListType _value) {
-                return Optional.of("[]");
+                return Optional.of("None");
             }
 
             @Override
             public Optional<String> visitSet(SetType _value) {
-                return Optional.of("[]");
+                return Optional.of("None");
             }
 
             @Override

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/client/ClientGenerator.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/client/ClientGenerator.java
@@ -29,24 +29,14 @@ import com.palantir.conjure.python.processors.typename.TypeNameProcessor;
 import com.palantir.conjure.python.types.ImportTypeVisitor;
 import com.palantir.conjure.python.types.MyPyTypeNameVisitor;
 import com.palantir.conjure.python.types.PythonTypeNameVisitor;
-import com.palantir.conjure.spec.ArgumentDefinition;
 import com.palantir.conjure.spec.EndpointDefinition;
-import com.palantir.conjure.spec.ExternalReference;
-import com.palantir.conjure.spec.ListType;
-import com.palantir.conjure.spec.MapType;
-import com.palantir.conjure.spec.OptionalType;
 import com.palantir.conjure.spec.PrimitiveType;
 import com.palantir.conjure.spec.ServiceDefinition;
-import com.palantir.conjure.spec.SetType;
 import com.palantir.conjure.spec.Type;
-import com.palantir.conjure.spec.Type.Visitor;
-import com.palantir.conjure.spec.TypeName;
 import com.palantir.conjure.visitor.DealiasingTypeVisitor;
 import com.palantir.conjure.visitor.ParameterTypeVisitor;
 import com.palantir.conjure.visitor.TypeVisitor;
-import com.palantir.logsafe.Safe;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 public final class ClientGenerator {
@@ -113,10 +103,14 @@ public final class ClientGenerator {
                                 CaseConverter.toCase(argEntry.getArgName().get(), CaseConverter.Case.SNAKE_CASE))
                         .paramType(argEntry.getParamType())
                         .myPyType(argEntry.getType().accept(myPyTypeNameVisitor))
-                        .defaultValue(getDefaultValue(argEntry))
                         .isOptional(dealiasingTypeVisitor
                                 .dealias(argEntry.getType())
                                 .fold(_typeDefinition -> false, type -> type.accept(TypeVisitor.IS_OPTIONAL)))
+                        .isCollection(dealiasingTypeVisitor
+                                .dealias(argEntry.getType())
+                                .fold(
+                                        _typeDefinition -> false,
+                                        type -> type.accept(TypeVisitor.IS_LIST) || type.accept(TypeVisitor.IS_SET)))
                         .build())
                 .collect(Collectors.toList());
 
@@ -146,54 +140,5 @@ public final class ClientGenerator {
                                 .fold(_typeDefinition -> false, type -> type.accept(TypeVisitor.IS_OPTIONAL)))
                         .orElse(false))
                 .build();
-    }
-
-    private static Optional<String> getDefaultValue(ArgumentDefinition argumentDefinition) {
-        Optional<String> emptyValue = argumentDefinition.getType().accept(new Visitor<>() {
-            @Override
-            public Optional<String> visitPrimitive(PrimitiveType _value) {
-                return Optional.empty();
-            }
-
-            @Override
-            public Optional<String> visitOptional(OptionalType _value) {
-                return Optional.empty();
-            }
-
-            @Override
-            public Optional<String> visitList(ListType _value) {
-                return Optional.of("None");
-            }
-
-            @Override
-            public Optional<String> visitSet(SetType _value) {
-                return Optional.of("None");
-            }
-
-            @Override
-            public Optional<String> visitMap(MapType _value) {
-                return Optional.empty();
-            }
-
-            @Override
-            public Optional<String> visitReference(TypeName _value) {
-                return Optional.empty();
-            }
-
-            @Override
-            public Optional<String> visitExternal(ExternalReference _value) {
-                return Optional.empty();
-            }
-
-            @Override
-            public Optional<String> visitUnknown(@Safe String _unknownType) {
-                return Optional.empty();
-            }
-        });
-
-        return emptyValue.flatMap(value -> argumentDefinition.getParamType().accept(ParameterTypeVisitor.IS_HEADER)
-                        || argumentDefinition.getParamType().accept(ParameterTypeVisitor.IS_QUERY)
-                ? Optional.of(value)
-                : Optional.empty());
     }
 }

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java
@@ -279,6 +279,12 @@ public interface PythonEndpointDefinition extends Emittable {
             if (!o1.isOptional() && o2.isOptional()) {
                 return -1;
             }
+            if (o1.defaultValue().isPresent() && o2.defaultValue().isEmpty()) {
+                return 1;
+            }
+            if (o1.defaultValue().isEmpty() && o2.defaultValue().isPresent()) {
+                return -1;
+            }
             return o1.pythonParamName().compareTo(o2.pythonParamName());
         }
     }

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java
@@ -112,6 +112,15 @@ public interface PythonEndpointDefinition extends Emittable {
                 poetWriter.writeIndentedLine("\"\"\"");
             });
 
+            // replace "None" with "[]"
+            for (PythonEndpointParam param : paramsWithHeader) {
+                if (param.isCollection()) {
+                    poetWriter.writeIndentedLine(String.format(
+                            "%s = %s if %s is not None else []",
+                            param.pythonParamName(), param.pythonParamName(), param.pythonParamName()));
+                }
+            }
+
             // header
             poetWriter.writeLine();
             poetWriter.writeIndentedLine("_headers: Dict[str, Any] = {");

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java
@@ -95,8 +95,12 @@ public interface PythonEndpointDefinition extends Emittable {
                             .join(paramsWithHeader.stream()
                                     .sorted(new PythonEndpointParamComparator())
                                     .map(param -> {
-                                        String typedParam =
-                                                String.format("%s: %s", param.pythonParamName(), param.myPyType());
+                                        String defaultValuePart = param.defaultValue()
+                                                .map(value -> "=" + value)
+                                                .orElse("");
+                                        String typedParam = String.format(
+                                                "%s: %s%s",
+                                                param.pythonParamName(), param.myPyType(), defaultValuePart);
                                         if (param.isOptional()) {
                                             return String.format("%s = None", typedParam);
                                         }
@@ -252,6 +256,8 @@ public interface PythonEndpointDefinition extends Emittable {
         String pythonParamName();
 
         String myPyType();
+
+        Optional<String> defaultValue();
 
         ParameterType paramType();
 

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java
@@ -81,6 +81,7 @@ public interface PythonEndpointDefinition extends Emittable {
                                     .pythonParamName("auth_header")
                                     .myPyType("str")
                                     .isOptional(false)
+                                    .isCollection(false)
                                     .paramType(ParameterType.header(
                                             HeaderParameterType.of(ParameterId.of("Authorization"))))
                                     .build())
@@ -95,13 +96,9 @@ public interface PythonEndpointDefinition extends Emittable {
                             .join(paramsWithHeader.stream()
                                     .sorted(new PythonEndpointParamComparator())
                                     .map(param -> {
-                                        String defaultValuePart = param.defaultValue()
-                                                .map(value -> "=" + value)
-                                                .orElse("");
-                                        String typedParam = String.format(
-                                                "%s: %s%s",
-                                                param.pythonParamName(), param.myPyType(), defaultValuePart);
-                                        if (param.isOptional()) {
+                                        String typedParam =
+                                                String.format("%s: %s", param.pythonParamName(), param.myPyType());
+                                        if (param.isOptional() || param.isCollection()) {
                                             return String.format("%s = None", typedParam);
                                         }
                                         return typedParam;
@@ -257,11 +254,11 @@ public interface PythonEndpointDefinition extends Emittable {
 
         String myPyType();
 
-        Optional<String> defaultValue();
-
         ParameterType paramType();
 
         boolean isOptional();
+
+        boolean isCollection();
 
         class Builder extends ImmutablePythonEndpointParam.Builder {}
 
@@ -279,10 +276,10 @@ public interface PythonEndpointDefinition extends Emittable {
             if (!o1.isOptional() && o2.isOptional()) {
                 return -1;
             }
-            if (o1.defaultValue().isPresent() && o2.defaultValue().isEmpty()) {
+            if (o1.isCollection() && !o2.isCollection()) {
                 return 1;
             }
-            if (o1.defaultValue().isEmpty() && o2.defaultValue().isPresent()) {
+            if (!o1.isCollection() && o2.isCollection()) {
                 return -1;
             }
             return o1.pythonParamName().compareTo(o2.pythonParamName());

--- a/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
@@ -325,7 +325,7 @@ class another_TestService(Service):
         _decoder = ConjureDecoder()
         return None if _response.status_code == 204 else _decoder.decode(_response.json(), OptionalTypeWrapper[str])
 
-    def test_query_params(self, auth_header: str, implicit: str, list: List[int]=[], set: List[int]=[], something: str) -> int:
+    def test_query_params(self, auth_header: str, implicit: str, list: List[int]=None, set: List[int]=None, something: str) -> int:
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',

--- a/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
@@ -325,7 +325,7 @@ class another_TestService(Service):
         _decoder = ConjureDecoder()
         return None if _response.status_code == 204 else _decoder.decode(_response.json(), OptionalTypeWrapper[str])
 
-    def test_query_params(self, auth_header: str, implicit: str, something: str, list: List[int]=None, set: List[int]=None) -> int:
+    def test_query_params(self, auth_header: str, implicit: str, something: str, list: List[int] = None, set: List[int] = None) -> int:
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',

--- a/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
@@ -325,7 +325,7 @@ class another_TestService(Service):
         _decoder = ConjureDecoder()
         return None if _response.status_code == 204 else _decoder.decode(_response.json(), OptionalTypeWrapper[str])
 
-    def test_query_params(self, auth_header: str, implicit: str, list: List[int]=None, set: List[int]=None, something: str) -> int:
+    def test_query_params(self, auth_header: str, implicit: str, something: str, list: List[int]=None, set: List[int]=None) -> int:
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',

--- a/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
@@ -326,6 +326,8 @@ class another_TestService(Service):
         return None if _response.status_code == 204 else _decoder.decode(_response.json(), OptionalTypeWrapper[str])
 
     def test_query_params(self, auth_header: str, implicit: str, something: str, list: List[int] = None, set: List[int] = None) -> int:
+        list = list if list is not None else []
+        set = set if set is not None else []
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',

--- a/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
@@ -325,7 +325,7 @@ class another_TestService(Service):
         _decoder = ConjureDecoder()
         return None if _response.status_code == 204 else _decoder.decode(_response.json(), OptionalTypeWrapper[str])
 
-    def test_query_params(self, auth_header: str, implicit: str, something: str) -> int:
+    def test_query_params(self, auth_header: str, implicit: str, list: List[int]=[], set: List[int]=[], something: str) -> int:
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
@@ -335,6 +335,8 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
             'different': something,
             'implicit': implicit,
+            'list': list,
+            'set': set,
         }
 
         _path_params: Dict[str, Any] = {

--- a/conjure-python-core/src/test/resources/types/example-service.yml
+++ b/conjure-python-core/src/test/resources/types/example-service.yml
@@ -178,6 +178,12 @@ services:
           implicit:
             type: rid
             param-type: query
+          list:
+            type: list<integer>
+            param-type: query
+          set:
+            type: set<integer>
+            param-type: query
         returns: integer
 
       testBoolean:

--- a/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
@@ -330,7 +330,7 @@ class another_TestService(Service):
         _decoder = ConjureDecoder()
         return None if _response.status_code == 204 else _decoder.decode(_response.json(), OptionalTypeWrapper[str])
 
-    def test_query_params(self, auth_header: str, implicit: str, something: str) -> int:
+    def test_query_params(self, auth_header: str, implicit: str, list: List[int]=[], set: List[int]=[], something: str) -> int:
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
@@ -340,6 +340,8 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
             'different': something,
             'implicit': implicit,
+            'list': list,
+            'set': set,
         }
 
         _path_params: Dict[str, Any] = {

--- a/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
@@ -330,7 +330,7 @@ class another_TestService(Service):
         _decoder = ConjureDecoder()
         return None if _response.status_code == 204 else _decoder.decode(_response.json(), OptionalTypeWrapper[str])
 
-    def test_query_params(self, auth_header: str, implicit: str, list: List[int]=None, set: List[int]=None, something: str) -> int:
+    def test_query_params(self, auth_header: str, implicit: str, something: str, list: List[int]=None, set: List[int]=None) -> int:
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',

--- a/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
@@ -330,7 +330,7 @@ class another_TestService(Service):
         _decoder = ConjureDecoder()
         return None if _response.status_code == 204 else _decoder.decode(_response.json(), OptionalTypeWrapper[str])
 
-    def test_query_params(self, auth_header: str, implicit: str, something: str, list: List[int]=None, set: List[int]=None) -> int:
+    def test_query_params(self, auth_header: str, implicit: str, something: str, list: List[int] = None, set: List[int] = None) -> int:
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',

--- a/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
@@ -330,7 +330,7 @@ class another_TestService(Service):
         _decoder = ConjureDecoder()
         return None if _response.status_code == 204 else _decoder.decode(_response.json(), OptionalTypeWrapper[str])
 
-    def test_query_params(self, auth_header: str, implicit: str, list: List[int]=[], set: List[int]=[], something: str) -> int:
+    def test_query_params(self, auth_header: str, implicit: str, list: List[int]=None, set: List[int]=None, something: str) -> int:
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',

--- a/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
@@ -331,6 +331,8 @@ class another_TestService(Service):
         return None if _response.status_code == 204 else _decoder.decode(_response.json(), OptionalTypeWrapper[str])
 
     def test_query_params(self, auth_header: str, implicit: str, something: str, list: List[int] = None, set: List[int] = None) -> int:
+        list = list if list is not None else []
+        set = set if set is not None else []
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',


### PR DESCRIPTION
Handle adding default query/header list/set parameters without breaking function callers

Fix https://github.com/palantir/conjure-python/issues/615