### PR TITLE
make auth_header optional to enable using _request_session.headers

### DIFF
--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java
@@ -79,8 +79,8 @@ public interface PythonEndpointDefinition extends Emittable {
                             .add(PythonEndpointParam.builder()
                                     .paramName("authHeader")
                                     .pythonParamName("auth_header")
-                                    .myPyType("str")
-                                    .isOptional(false)
+                                    .myPyType("Optional[str]")
+                                    .isOptional(true)
                                     .isCollection(false)
                                     .paramType(ParameterType.header(
                                             HeaderParameterType.of(ParameterId.of("Authorization"))))
@@ -98,8 +98,14 @@ public interface PythonEndpointDefinition extends Emittable {
                                     .map(param -> {
                                         String typedParam =
                                                 String.format("%s: %s", param.pythonParamName(), param.myPyType());
-                                        if (param.isOptional() || param.isCollection()) {
+                                        if (param.isOptional()) {
                                             return String.format("%s = None", typedParam);
+                                        } else if (param.isCollection()) {
+                                            return String.format("%s = []", typedParam);
+                                        } else if (param.paramType().accept(ParameterTypeVisitor.IS_HEADER)) {
+                                            return String.format(
+                                                    "%s: Optional[%s] = None",
+                                                    param.pythonParamName(), param.myPyType());
                                         }
                                         return typedParam;
                                     })
@@ -111,15 +117,6 @@ public interface PythonEndpointDefinition extends Emittable {
                 poetWriter.writeIndentedLine(docs.get().trim());
                 poetWriter.writeIndentedLine("\"\"\"");
             });
-
-            // replace "None" with "[]"
-            for (PythonEndpointParam param : paramsWithHeader) {
-                if (param.isCollection()) {
-                    poetWriter.writeIndentedLine(String.format(
-                            "%s = %s if %s is not None else []",
-                            param.pythonParamName(), param.pythonParamName(), param.pythonParamName()));
-                }
-            }
 
             // header
             poetWriter.writeLine();
@@ -138,19 +135,26 @@ public interface PythonEndpointDefinition extends Emittable {
                         "'Content-Type': '%s',",
                         isRequestBinary() ? MediaType.APPLICATION_OCTET_STREAM : MediaType.APPLICATION_JSON);
             }
-            paramsWithHeader.stream()
-                    .filter(param -> param.paramType().accept(ParameterTypeVisitor.IS_HEADER))
-                    .forEach(param -> {
-                        poetWriter.writeIndentedLine(
-                                "'%s': %s,",
-                                param.paramType()
-                                        .accept(ParameterTypeVisitor.HEADER)
-                                        .getParamId()
-                                        .get(),
-                                param.pythonParamName());
-                    });
             poetWriter.decreaseIndent();
             poetWriter.writeIndentedLine("}");
+
+            // optional header params
+            poetWriter.writeLine();
+            poetWriter.writeIndentedLine("_header_params: Dict[str, Any] = {");
+            poetWriter.increaseIndent();
+            paramsWithHeader.stream()
+                    .filter(param -> param.paramType().accept(ParameterTypeVisitor.IS_HEADER))
+                    .forEach(param -> poetWriter.writeIndentedLine(
+                            "'%s': %s,",
+                            param.paramType()
+                                    .accept(ParameterTypeVisitor.HEADER)
+                                    .getParamId()
+                                    .get(),
+                            param.pythonParamName()));
+            poetWriter.decreaseIndent();
+            poetWriter.writeIndentedLine("}");
+            poetWriter.writeLine();
+            poetWriter.writeIndentedLine("_headers.update((k, v) for k, v in _header_params.items() if v is not None)");
 
             // params
             poetWriter.writeLine();
@@ -279,16 +283,46 @@ public interface PythonEndpointDefinition extends Emittable {
     final class PythonEndpointParamComparator implements Comparator<PythonEndpointParam> {
         @Override
         public int compare(PythonEndpointParam o1, PythonEndpointParam o2) {
+            if (o1.isOptional() || o2.isOptional()) {
+                return compareOptional(o1, o2);
+            }
+            if (o1.isCollection() || o2.isCollection()) {
+                return compareCollection(o1, o2);
+            }
+            if (o1.paramType().accept(ParameterTypeVisitor.IS_HEADER)
+                    || o2.paramType().accept(ParameterTypeVisitor.IS_HEADER)) {
+                return compareHeader(o1, o2);
+            }
+            return o1.pythonParamName().compareTo(o2.pythonParamName());
+        }
+
+        private int compareOptional(PythonEndpointParam o1, PythonEndpointParam o2) {
             if (o1.isOptional() && !o2.isOptional()) {
                 return 1;
             }
             if (!o1.isOptional() && o2.isOptional()) {
                 return -1;
             }
+            return o1.pythonParamName().compareTo(o2.pythonParamName());
+        }
+
+        private int compareCollection(PythonEndpointParam o1, PythonEndpointParam o2) {
             if (o1.isCollection() && !o2.isCollection()) {
                 return 1;
             }
             if (!o1.isCollection() && o2.isCollection()) {
+                return -1;
+            }
+            return o1.pythonParamName().compareTo(o2.pythonParamName());
+        }
+
+        private int compareHeader(PythonEndpointParam o1, PythonEndpointParam o2) {
+            if (o1.paramType().accept(ParameterTypeVisitor.IS_HEADER)
+                    && !o2.paramType().accept(ParameterTypeVisitor.IS_HEADER)) {
+                return 1;
+            }
+            if (!o1.paramType().accept(ParameterTypeVisitor.IS_HEADER)
+                    && o2.paramType().accept(ParameterTypeVisitor.IS_HEADER)) {
                 return -1;
             }
             return o1.pythonParamName().compareTo(o2.pythonParamName());

--- a/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
@@ -25,15 +25,20 @@ class another_TestService(Service):
     A Markdown description of the service. "Might end with quotes"
     """
 
-    def get_file_systems(self, auth_header: str) -> Dict[str, "product_datasets_BackingFileSystem"]:
+    def get_file_systems(self, auth_header: Optional[str] = None) -> Dict[str, "product_datasets_BackingFileSystem"]:
         """
         Returns a mapping from file system id to backing file system configuration.
         """
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
+        }
+
+        _header_params: Dict[str, Any] = {
             'Authorization': auth_header,
         }
+
+        _headers.update((k, v) for k, v in _header_params.items() if v is not None)
 
         _params: Dict[str, Any] = {
         }
@@ -56,14 +61,19 @@ class another_TestService(Service):
         _decoder = ConjureDecoder()
         return _decoder.decode(_response.json(), Dict[str, product_datasets_BackingFileSystem])
 
-    def create_dataset(self, auth_header: str, request: "product_CreateDatasetRequest", test_header_arg: str) -> "product_datasets_Dataset":
+    def create_dataset(self, request: "product_CreateDatasetRequest", test_header_arg: Optional[str] = None, auth_header: Optional[str] = None) -> "product_datasets_Dataset":
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
             'Content-Type': 'application/json',
+        }
+
+        _header_params: Dict[str, Any] = {
             'Authorization': auth_header,
             'Test-Header': test_header_arg,
         }
+
+        _headers.update((k, v) for k, v in _header_params.items() if v is not None)
 
         _params: Dict[str, Any] = {
         }
@@ -86,12 +96,17 @@ class another_TestService(Service):
         _decoder = ConjureDecoder()
         return _decoder.decode(_response.json(), product_datasets_Dataset)
 
-    def get_dataset(self, auth_header: str, dataset_rid: str) -> Optional["product_datasets_Dataset"]:
+    def get_dataset(self, dataset_rid: str, auth_header: Optional[str] = None) -> Optional["product_datasets_Dataset"]:
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
+        }
+
+        _header_params: Dict[str, Any] = {
             'Authorization': auth_header,
         }
+
+        _headers.update((k, v) for k, v in _header_params.items() if v is not None)
 
         _params: Dict[str, Any] = {
         }
@@ -115,12 +130,17 @@ class another_TestService(Service):
         _decoder = ConjureDecoder()
         return None if _response.status_code == 204 else _decoder.decode(_response.json(), OptionalTypeWrapper[product_datasets_Dataset])
 
-    def get_raw_data(self, auth_header: str, dataset_rid: str) -> Any:
+    def get_raw_data(self, dataset_rid: str, auth_header: Optional[str] = None) -> Any:
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/octet-stream',
+        }
+
+        _header_params: Dict[str, Any] = {
             'Authorization': auth_header,
         }
+
+        _headers.update((k, v) for k, v in _header_params.items() if v is not None)
 
         _params: Dict[str, Any] = {
         }
@@ -146,12 +166,17 @@ class another_TestService(Service):
         _raw.decode_content = True
         return _raw
 
-    def maybe_get_raw_data(self, auth_header: str, dataset_rid: str) -> Optional[Any]:
+    def maybe_get_raw_data(self, dataset_rid: str, auth_header: Optional[str] = None) -> Optional[Any]:
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
+        }
+
+        _header_params: Dict[str, Any] = {
             'Authorization': auth_header,
         }
+
+        _headers.update((k, v) for k, v in _header_params.items() if v is not None)
 
         _params: Dict[str, Any] = {
         }
@@ -175,13 +200,18 @@ class another_TestService(Service):
         _decoder = ConjureDecoder()
         return None if _response.status_code == 204 else _decoder.decode(_response.json(), OptionalTypeWrapper[BinaryType])
 
-    def upload_raw_data(self, auth_header: str, input: Any) -> None:
+    def upload_raw_data(self, input: Any, auth_header: Optional[str] = None) -> None:
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
             'Content-Type': 'application/octet-stream',
+        }
+
+        _header_params: Dict[str, Any] = {
             'Authorization': auth_header,
         }
+
+        _headers.update((k, v) for k, v in _header_params.items() if v is not None)
 
         _params: Dict[str, Any] = {
         }
@@ -203,13 +233,18 @@ class another_TestService(Service):
 
         return
 
-    def get_branches(self, auth_header: str, dataset_rid: str, message: Optional[str] = None, page_size: Optional[int] = None) -> List[str]:
+    def get_branches(self, dataset_rid: str, auth_header: Optional[str] = None, message: Optional[str] = None, page_size: Optional[int] = None) -> List[str]:
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
+        }
+
+        _header_params: Dict[str, Any] = {
             'Authorization': auth_header,
             'Special-Message': message,
         }
+
+        _headers.update((k, v) for k, v in _header_params.items() if v is not None)
 
         _params: Dict[str, Any] = {
             'pageSize': page_size,
@@ -234,15 +269,20 @@ class another_TestService(Service):
         _decoder = ConjureDecoder()
         return _decoder.decode(_response.json(), List[str])
 
-    def get_branches_deprecated(self, auth_header: str, dataset_rid: str) -> List[str]:
+    def get_branches_deprecated(self, dataset_rid: str, auth_header: Optional[str] = None) -> List[str]:
         """
         Gets all branches of this dataset.
         """
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
+        }
+
+        _header_params: Dict[str, Any] = {
             'Authorization': auth_header,
         }
+
+        _headers.update((k, v) for k, v in _header_params.items() if v is not None)
 
         _params: Dict[str, Any] = {
         }
@@ -266,12 +306,17 @@ class another_TestService(Service):
         _decoder = ConjureDecoder()
         return _decoder.decode(_response.json(), List[str])
 
-    def resolve_branch(self, auth_header: str, branch: str, dataset_rid: str) -> Optional[str]:
+    def resolve_branch(self, branch: str, dataset_rid: str, auth_header: Optional[str] = None) -> Optional[str]:
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
+        }
+
+        _header_params: Dict[str, Any] = {
             'Authorization': auth_header,
         }
+
+        _headers.update((k, v) for k, v in _header_params.items() if v is not None)
 
         _params: Dict[str, Any] = {
         }
@@ -296,12 +341,17 @@ class another_TestService(Service):
         _decoder = ConjureDecoder()
         return None if _response.status_code == 204 else _decoder.decode(_response.json(), OptionalTypeWrapper[str])
 
-    def test_param(self, auth_header: str, dataset_rid: str) -> Optional[str]:
+    def test_param(self, dataset_rid: str, auth_header: Optional[str] = None) -> Optional[str]:
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
+        }
+
+        _header_params: Dict[str, Any] = {
             'Authorization': auth_header,
         }
+
+        _headers.update((k, v) for k, v in _header_params.items() if v is not None)
 
         _params: Dict[str, Any] = {
         }
@@ -325,14 +375,17 @@ class another_TestService(Service):
         _decoder = ConjureDecoder()
         return None if _response.status_code == 204 else _decoder.decode(_response.json(), OptionalTypeWrapper[str])
 
-    def test_query_params(self, auth_header: str, implicit: str, something: str, list: List[int] = None, set: List[int] = None) -> int:
-        list = list if list is not None else []
-        set = set if set is not None else []
+    def test_query_params(self, implicit: str, something: str, list: List[int] = [], set: List[int] = [], auth_header: Optional[str] = None) -> int:
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
+        }
+
+        _header_params: Dict[str, Any] = {
             'Authorization': auth_header,
         }
+
+        _headers.update((k, v) for k, v in _header_params.items() if v is not None)
 
         _params: Dict[str, Any] = {
             'different': something,
@@ -359,12 +412,17 @@ class another_TestService(Service):
         _decoder = ConjureDecoder()
         return _decoder.decode(_response.json(), int)
 
-    def test_boolean(self, auth_header: str) -> bool:
+    def test_boolean(self, auth_header: Optional[str] = None) -> bool:
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
+        }
+
+        _header_params: Dict[str, Any] = {
             'Authorization': auth_header,
         }
+
+        _headers.update((k, v) for k, v in _header_params.items() if v is not None)
 
         _params: Dict[str, Any] = {
         }
@@ -387,12 +445,17 @@ class another_TestService(Service):
         _decoder = ConjureDecoder()
         return _decoder.decode(_response.json(), bool)
 
-    def test_double(self, auth_header: str) -> float:
+    def test_double(self, auth_header: Optional[str] = None) -> float:
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
+        }
+
+        _header_params: Dict[str, Any] = {
             'Authorization': auth_header,
         }
+
+        _headers.update((k, v) for k, v in _header_params.items() if v is not None)
 
         _params: Dict[str, Any] = {
         }
@@ -415,12 +478,17 @@ class another_TestService(Service):
         _decoder = ConjureDecoder()
         return _decoder.decode(_response.json(), float)
 
-    def test_integer(self, auth_header: str) -> int:
+    def test_integer(self, auth_header: Optional[str] = None) -> int:
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
+        }
+
+        _header_params: Dict[str, Any] = {
             'Authorization': auth_header,
         }
+
+        _headers.update((k, v) for k, v in _header_params.items() if v is not None)
 
         _params: Dict[str, Any] = {
         }

--- a/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
@@ -30,15 +30,20 @@ class another_TestService(Service):
     A Markdown description of the service. "Might end with quotes"
     """
 
-    def get_file_systems(self, auth_header: str) -> Dict[str, "product_datasets_BackingFileSystem"]:
+    def get_file_systems(self, auth_header: Optional[str] = None) -> Dict[str, "product_datasets_BackingFileSystem"]:
         """
         Returns a mapping from file system id to backing file system configuration.
         """
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
+        }
+
+        _header_params: Dict[str, Any] = {
             'Authorization': auth_header,
         }
+
+        _headers.update((k, v) for k, v in _header_params.items() if v is not None)
 
         _params: Dict[str, Any] = {
         }
@@ -61,14 +66,19 @@ class another_TestService(Service):
         _decoder = ConjureDecoder()
         return _decoder.decode(_response.json(), Dict[str, product_datasets_BackingFileSystem])
 
-    def create_dataset(self, auth_header: str, request: "product_CreateDatasetRequest", test_header_arg: str) -> "product_datasets_Dataset":
+    def create_dataset(self, request: "product_CreateDatasetRequest", test_header_arg: Optional[str] = None, auth_header: Optional[str] = None) -> "product_datasets_Dataset":
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
             'Content-Type': 'application/json',
+        }
+
+        _header_params: Dict[str, Any] = {
             'Authorization': auth_header,
             'Test-Header': test_header_arg,
         }
+
+        _headers.update((k, v) for k, v in _header_params.items() if v is not None)
 
         _params: Dict[str, Any] = {
         }
@@ -91,12 +101,17 @@ class another_TestService(Service):
         _decoder = ConjureDecoder()
         return _decoder.decode(_response.json(), product_datasets_Dataset)
 
-    def get_dataset(self, auth_header: str, dataset_rid: str) -> Optional["product_datasets_Dataset"]:
+    def get_dataset(self, dataset_rid: str, auth_header: Optional[str] = None) -> Optional["product_datasets_Dataset"]:
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
+        }
+
+        _header_params: Dict[str, Any] = {
             'Authorization': auth_header,
         }
+
+        _headers.update((k, v) for k, v in _header_params.items() if v is not None)
 
         _params: Dict[str, Any] = {
         }
@@ -120,12 +135,17 @@ class another_TestService(Service):
         _decoder = ConjureDecoder()
         return None if _response.status_code == 204 else _decoder.decode(_response.json(), OptionalTypeWrapper[product_datasets_Dataset])
 
-    def get_raw_data(self, auth_header: str, dataset_rid: str) -> Any:
+    def get_raw_data(self, dataset_rid: str, auth_header: Optional[str] = None) -> Any:
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/octet-stream',
+        }
+
+        _header_params: Dict[str, Any] = {
             'Authorization': auth_header,
         }
+
+        _headers.update((k, v) for k, v in _header_params.items() if v is not None)
 
         _params: Dict[str, Any] = {
         }
@@ -151,12 +171,17 @@ class another_TestService(Service):
         _raw.decode_content = True
         return _raw
 
-    def maybe_get_raw_data(self, auth_header: str, dataset_rid: str) -> Optional[Any]:
+    def maybe_get_raw_data(self, dataset_rid: str, auth_header: Optional[str] = None) -> Optional[Any]:
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
+        }
+
+        _header_params: Dict[str, Any] = {
             'Authorization': auth_header,
         }
+
+        _headers.update((k, v) for k, v in _header_params.items() if v is not None)
 
         _params: Dict[str, Any] = {
         }
@@ -180,13 +205,18 @@ class another_TestService(Service):
         _decoder = ConjureDecoder()
         return None if _response.status_code == 204 else _decoder.decode(_response.json(), OptionalTypeWrapper[BinaryType])
 
-    def upload_raw_data(self, auth_header: str, input: Any) -> None:
+    def upload_raw_data(self, input: Any, auth_header: Optional[str] = None) -> None:
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
             'Content-Type': 'application/octet-stream',
+        }
+
+        _header_params: Dict[str, Any] = {
             'Authorization': auth_header,
         }
+
+        _headers.update((k, v) for k, v in _header_params.items() if v is not None)
 
         _params: Dict[str, Any] = {
         }
@@ -208,13 +238,18 @@ class another_TestService(Service):
 
         return
 
-    def get_branches(self, auth_header: str, dataset_rid: str, message: Optional[str] = None, page_size: Optional[int] = None) -> List[str]:
+    def get_branches(self, dataset_rid: str, auth_header: Optional[str] = None, message: Optional[str] = None, page_size: Optional[int] = None) -> List[str]:
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
+        }
+
+        _header_params: Dict[str, Any] = {
             'Authorization': auth_header,
             'Special-Message': message,
         }
+
+        _headers.update((k, v) for k, v in _header_params.items() if v is not None)
 
         _params: Dict[str, Any] = {
             'pageSize': page_size,
@@ -239,15 +274,20 @@ class another_TestService(Service):
         _decoder = ConjureDecoder()
         return _decoder.decode(_response.json(), List[str])
 
-    def get_branches_deprecated(self, auth_header: str, dataset_rid: str) -> List[str]:
+    def get_branches_deprecated(self, dataset_rid: str, auth_header: Optional[str] = None) -> List[str]:
         """
         Gets all branches of this dataset.
         """
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
+        }
+
+        _header_params: Dict[str, Any] = {
             'Authorization': auth_header,
         }
+
+        _headers.update((k, v) for k, v in _header_params.items() if v is not None)
 
         _params: Dict[str, Any] = {
         }
@@ -271,12 +311,17 @@ class another_TestService(Service):
         _decoder = ConjureDecoder()
         return _decoder.decode(_response.json(), List[str])
 
-    def resolve_branch(self, auth_header: str, branch: str, dataset_rid: str) -> Optional[str]:
+    def resolve_branch(self, branch: str, dataset_rid: str, auth_header: Optional[str] = None) -> Optional[str]:
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
+        }
+
+        _header_params: Dict[str, Any] = {
             'Authorization': auth_header,
         }
+
+        _headers.update((k, v) for k, v in _header_params.items() if v is not None)
 
         _params: Dict[str, Any] = {
         }
@@ -301,12 +346,17 @@ class another_TestService(Service):
         _decoder = ConjureDecoder()
         return None if _response.status_code == 204 else _decoder.decode(_response.json(), OptionalTypeWrapper[str])
 
-    def test_param(self, auth_header: str, dataset_rid: str) -> Optional[str]:
+    def test_param(self, dataset_rid: str, auth_header: Optional[str] = None) -> Optional[str]:
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
+        }
+
+        _header_params: Dict[str, Any] = {
             'Authorization': auth_header,
         }
+
+        _headers.update((k, v) for k, v in _header_params.items() if v is not None)
 
         _params: Dict[str, Any] = {
         }
@@ -330,14 +380,17 @@ class another_TestService(Service):
         _decoder = ConjureDecoder()
         return None if _response.status_code == 204 else _decoder.decode(_response.json(), OptionalTypeWrapper[str])
 
-    def test_query_params(self, auth_header: str, implicit: str, something: str, list: List[int] = None, set: List[int] = None) -> int:
-        list = list if list is not None else []
-        set = set if set is not None else []
+    def test_query_params(self, implicit: str, something: str, list: List[int] = [], set: List[int] = [], auth_header: Optional[str] = None) -> int:
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
+        }
+
+        _header_params: Dict[str, Any] = {
             'Authorization': auth_header,
         }
+
+        _headers.update((k, v) for k, v in _header_params.items() if v is not None)
 
         _params: Dict[str, Any] = {
             'different': something,
@@ -364,12 +417,17 @@ class another_TestService(Service):
         _decoder = ConjureDecoder()
         return _decoder.decode(_response.json(), int)
 
-    def test_boolean(self, auth_header: str) -> bool:
+    def test_boolean(self, auth_header: Optional[str] = None) -> bool:
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
+        }
+
+        _header_params: Dict[str, Any] = {
             'Authorization': auth_header,
         }
+
+        _headers.update((k, v) for k, v in _header_params.items() if v is not None)
 
         _params: Dict[str, Any] = {
         }
@@ -392,12 +450,17 @@ class another_TestService(Service):
         _decoder = ConjureDecoder()
         return _decoder.decode(_response.json(), bool)
 
-    def test_double(self, auth_header: str) -> float:
+    def test_double(self, auth_header: Optional[str] = None) -> float:
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
+        }
+
+        _header_params: Dict[str, Any] = {
             'Authorization': auth_header,
         }
+
+        _headers.update((k, v) for k, v in _header_params.items() if v is not None)
 
         _params: Dict[str, Any] = {
         }
@@ -420,12 +483,17 @@ class another_TestService(Service):
         _decoder = ConjureDecoder()
         return _decoder.decode(_response.json(), float)
 
-    def test_integer(self, auth_header: str) -> int:
+    def test_integer(self, auth_header: Optional[str] = None) -> int:
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
+        }
+
+        _header_params: Dict[str, Any] = {
             'Authorization': auth_header,
         }
+
+        _headers.update((k, v) for k, v in _header_params.items() if v is not None)
 
         _params: Dict[str, Any] = {
         }
@@ -463,6 +531,11 @@ class nested_deeply_nested_service_DeeplyNestedService(Service):
             'Content-Type': 'application/json',
         }
 
+        _header_params: Dict[str, Any] = {
+        }
+
+        _headers.update((k, v) for k, v in _header_params.items() if v is not None)
+
         _params: Dict[str, Any] = {
         }
 
@@ -499,6 +572,11 @@ class nested_service2_SimpleNestedService2(Service):
             'Content-Type': 'application/json',
         }
 
+        _header_params: Dict[str, Any] = {
+        }
+
+        _headers.update((k, v) for k, v in _header_params.items() if v is not None)
+
         _params: Dict[str, Any] = {
         }
 
@@ -534,6 +612,11 @@ class nested_service_SimpleNestedService(Service):
             'Accept': 'application/json',
             'Content-Type': 'application/json',
         }
+
+        _header_params: Dict[str, Any] = {
+        }
+
+        _headers.update((k, v) for k, v in _header_params.items() if v is not None)
 
         _params: Dict[str, Any] = {
         }
@@ -1673,6 +1756,11 @@ class with_imports_ImportService(Service):
             'Accept': 'application/json',
             'Content-Type': 'application/json',
         }
+
+        _header_params: Dict[str, Any] = {
+        }
+
+        _headers.update((k, v) for k, v in _header_params.items() if v is not None)
 
         _params: Dict[str, Any] = {
         }

--- a/conjure-python-verifier/python/Pipfile.lock
+++ b/conjure-python-verifier/python/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4df96be54432cef702bcbe24387e818063de754427994ea403c63a99bee244f3"
+            "sha256": "9ed6fc59e331d48fb2d2a2ff22a4998462b282ea15856f6df11615da7c242c37"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,247 +18,127 @@
     "default": {
         "certifi": {
             "hashes": [
-                "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872",
-                "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"
+                "sha256:0d9c601124e5a6ba9712dbc60d9c53c21e34f5f641fe83002317394311bdce14",
+                "sha256:90c1a32f1d68f940488354e36370f6cca89f0f106db09518524c88d6ed83f382"
             ],
-            "version": "==2021.10.8"
+            "markers": "python_version >= '3.6'",
+            "version": "==2022.9.24"
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597",
-                "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"
+                "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845",
+                "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"
             ],
-            "markers": "python_version >= '3'",
-            "version": "==2.0.12"
+            "markers": "python_full_version >= '3.6.0'",
+            "version": "==2.1.1"
         },
         "conjure-python-client": {
             "hashes": [
-                "sha256:281a2170f37278c7290967ad75fb18194aabb341738eb4247315c2f501e668ae",
-                "sha256:e3c816439ca1303cf0df5d1b8533970b80d6d0f887d141557217fb91180c9421"
+                "sha256:77c92289d2c4c360c9bf306da1b3ea64ad4a24a9007e1727f9453135e103751d",
+                "sha256:fab6c7d4019e2913d4ee44842b2c75f26837bf5745dcbddda97174e5f318a90c"
             ],
             "index": "pypi",
-            "version": "==2.0.0"
-        },
-        "distlib": {
-            "hashes": [
-                "sha256:6564fe0a8f51e734df6333d08b8b94d4ea8ee6b99b5ed50613f731fd4089f34b",
-                "sha256:e4b58818180336dc9c529bfb9a0b58728ffc09ad92027a3f30b7cd91e3458579"
-            ],
-            "version": "==0.3.4"
-        },
-        "filelock": {
-            "hashes": [
-                "sha256:9cd540a9352e432c7246a48fe4e8712b10acb1df2ad1f30e8c070b82ae1fed85",
-                "sha256:f8314284bfffbdcfa0ff3d7992b023d4c628ced6feb957351d4c48d059f56bc0"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==3.6.0"
+            "version": "==2.1.0"
         },
         "idna": {
             "hashes": [
-                "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
-                "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
+                "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4",
+                "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"
             ],
-            "markers": "python_version >= '3'",
-            "version": "==3.3"
-        },
-        "packaging": {
-            "hashes": [
-                "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
-                "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
-            ],
-            "markers": "python_version >= '3.6'",
-            "version": "==21.3"
-        },
-        "pip": {
-            "hashes": [
-                "sha256:c146f331f0805c77017c6bb9740cec4a49a0d4582d0c3cc8244b057f83eca359",
-                "sha256:f29d589df8c8ab99c060e68ad294c4a9ed896624f6368c5349d70aa581b333d0"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==22.0.3"
-        },
-        "pipenv": {
-            "hashes": [
-                "sha256:3b80b4512934b9d8e8ce12c988394642ff96bb697680e5b092e59af503178327",
-                "sha256:f84d7119239b22ab2ac2b8fbc7d619d83cf41135206d72a17c4f151cda529fd0"
-            ],
-            "markers": "python_version >= '3.6'",
-            "version": "==2022.1.8"
-        },
-        "platformdirs": {
-            "hashes": [
-                "sha256:7535e70dfa32e84d4b34996ea99c5e432fa29a708d0f4e394bbcb2a8faa4f16d",
-                "sha256:bcae7cab893c2d310a711b70b24efb93334febe65f8de776ee320b517471e227"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2.5.1"
-        },
-        "pluggy": {
-            "hashes": [
-                "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159",
-                "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"
-            ],
-            "markers": "python_version >= '3.6'",
-            "version": "==1.0.0"
-        },
-        "py": {
-            "hashes": [
-                "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719",
-                "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==1.11.0"
-        },
-        "pyparsing": {
-            "hashes": [
-                "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea",
-                "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"
-            ],
-            "markers": "python_version >= '3.6'",
-            "version": "==3.0.7"
+            "markers": "python_version >= '3.5'",
+            "version": "==3.4"
         },
         "requests": {
             "hashes": [
-                "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61",
-                "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"
+                "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983",
+                "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==2.27.1"
-        },
-        "setuptools": {
-            "hashes": [
-                "sha256:2347b2b432c891a863acadca2da9ac101eae6169b1d3dfee2ec605ecd50dbfe5",
-                "sha256:e4f30b9f84e5ab3decf945113119649fec09c1fc3507c6ebffec75646c56e62b"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==60.9.3"
-        },
-        "six": {
-            "hashes": [
-                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
-                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.16.0"
-        },
-        "toml": {
-            "hashes": [
-                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
-                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
-            ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.10.2"
-        },
-        "tox": {
-            "hashes": [
-                "sha256:67e0e32c90e278251fea45b696d0fef3879089ccbe979b0c556d35d5a70e2993",
-                "sha256:be3362472a33094bce26727f5f771ca0facf6dafa217f65875314e9a6600c95c"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==3.24.5"
-        },
-        "tox-pipenv": {
-            "hashes": [
-                "sha256:5fe576294be7a5a14ba4bdea729d9c738e6c7d423ab84273c9b106d5b2508999",
-                "sha256:f51476491b52c22455fe37f31aa1a0c5aa9798d223f19be58dfadcf79e503362"
-            ],
-            "index": "pypi",
-            "version": "==1.10.1"
+            "markers": "python_version >= '3.7' and python_version < '4'",
+            "version": "==2.28.1"
         },
         "urllib3": {
             "hashes": [
-                "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed",
-                "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"
+                "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e",
+                "sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==1.26.8"
-        },
-        "virtualenv": {
-            "hashes": [
-                "sha256:01f5f80744d24a3743ce61858123488e91cb2dd1d3bdf92adaf1bba39ffdedf0",
-                "sha256:e7b34c9474e6476ee208c43a4d9ac1510b041c68347eabfe9a9ea0c86aa0a46b"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==20.13.2"
-        },
-        "virtualenv-clone": {
-            "hashes": [
-                "sha256:418ee935c36152f8f153c79824bb93eaf6f0f7984bae31d3f48f350b9183501a",
-                "sha256:44d5263bceed0bac3e1424d64f798095233b64def1c5689afa43dc3223caf5b0"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.5.7"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'",
+            "version": "==1.26.12"
         }
     },
     "develop": {
         "astroid": {
             "hashes": [
-                "sha256:1efdf4e867d4d8ba4a9f6cf9ce07cd182c4c41de77f23814feb27ca93ca9d877",
-                "sha256:506daabe5edffb7e696ad82483ad0228245a9742ed7d2d8c9cdb31537decf9f6"
+                "sha256:81f870105d892e73bf535da77a8261aa5bde838fa4ed12bb2f435291a098c581",
+                "sha256:997e0c735df60d4a4caff27080a3afc51f9bdd693d3572a4a0b7090b645c36c5"
             ],
-            "markers": "python_full_version >= '3.6.2'",
-            "version": "==2.9.3"
+            "markers": "python_full_version >= '3.7.2'",
+            "version": "==2.12.10"
         },
         "attrs": {
             "hashes": [
-                "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4",
-                "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"
+                "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6",
+                "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==21.4.0"
+            "markers": "python_version >= '3.5'",
+            "version": "==22.1.0"
         },
         "black": {
             "hashes": [
-                "sha256:07e5c049442d7ca1a2fc273c79d1aecbbf1bc858f62e8184abe1ad175c4f7cc2",
-                "sha256:0e21e1f1efa65a50e3960edd068b6ae6d64ad6235bd8bfea116a03b21836af71",
-                "sha256:1297c63b9e1b96a3d0da2d85d11cd9bf8664251fd69ddac068b98dc4f34f73b6",
-                "sha256:228b5ae2c8e3d6227e4bde5920d2fc66cc3400fde7bcc74f480cb07ef0b570d5",
-                "sha256:2d6f331c02f0f40aa51a22e479c8209d37fcd520c77721c034517d44eecf5912",
-                "sha256:2ff96450d3ad9ea499fc4c60e425a1439c2120cbbc1ab959ff20f7c76ec7e866",
-                "sha256:3524739d76b6b3ed1132422bf9d82123cd1705086723bc3e235ca39fd21c667d",
-                "sha256:35944b7100af4a985abfcaa860b06af15590deb1f392f06c8683b4381e8eeaf0",
-                "sha256:373922fc66676133ddc3e754e4509196a8c392fec3f5ca4486673e685a421321",
-                "sha256:5fa1db02410b1924b6749c245ab38d30621564e658297484952f3d8a39fce7e8",
-                "sha256:6f2f01381f91c1efb1451998bd65a129b3ed6f64f79663a55fe0e9b74a5f81fd",
-                "sha256:742ce9af3086e5bd07e58c8feb09dbb2b047b7f566eb5f5bc63fd455814979f3",
-                "sha256:7835fee5238fc0a0baf6c9268fb816b5f5cd9b8793423a75e8cd663c48d073ba",
-                "sha256:8871fcb4b447206904932b54b567923e5be802b9b19b744fdff092bd2f3118d0",
-                "sha256:a7c0192d35635f6fc1174be575cb7915e92e5dd629ee79fdaf0dcfa41a80afb5",
-                "sha256:b1a5ed73ab4c482208d20434f700d514f66ffe2840f63a6252ecc43a9bc77e8a",
-                "sha256:c8226f50b8c34a14608b848dc23a46e5d08397d009446353dad45e04af0c8e28",
-                "sha256:ccad888050f5393f0d6029deea2a33e5ae371fd182a697313bdbd835d3edaf9c",
-                "sha256:dae63f2dbf82882fa3b2a3c49c32bffe144970a573cd68d247af6560fc493ae1",
-                "sha256:e2f69158a7d120fd641d1fa9a921d898e20d52e44a74a6fbbcc570a62a6bc8ab",
-                "sha256:efbadd9b52c060a8fc3b9658744091cb33c31f830b3f074422ed27bad2b18e8f",
-                "sha256:f5660feab44c2e3cb24b2419b998846cbb01c23c7fe645fee45087efa3da2d61",
-                "sha256:fdb8754b453fb15fad3f72cd9cad3e16776f0964d67cf30ebcbf10327a3777a3"
+                "sha256:14ff67aec0a47c424bc99b71005202045dc09270da44a27848d534600ac64fc7",
+                "sha256:197df8509263b0b8614e1df1756b1dd41be6738eed2ba9e9769f3880c2b9d7b6",
+                "sha256:1e464456d24e23d11fced2bc8c47ef66d471f845c7b7a42f3bd77bf3d1789650",
+                "sha256:2039230db3c6c639bd84efe3292ec7b06e9214a2992cd9beb293d639c6402edb",
+                "sha256:21199526696b8f09c3997e2b4db8d0b108d801a348414264d2eb8eb2532e540d",
+                "sha256:2644b5d63633702bc2c5f3754b1b475378fbbfb481f62319388235d0cd104c2d",
+                "sha256:432247333090c8c5366e69627ccb363bc58514ae3e63f7fc75c54b1ea80fa7de",
+                "sha256:444ebfb4e441254e87bad00c661fe32df9969b2bf224373a448d8aca2132b395",
+                "sha256:5b9b29da4f564ba8787c119f37d174f2b69cdfdf9015b7d8c5c16121ddc054ae",
+                "sha256:5cc42ca67989e9c3cf859e84c2bf014f6633db63d1cbdf8fdb666dcd9e77e3fa",
+                "sha256:5d8f74030e67087b219b032aa33a919fae8806d49c867846bfacde57f43972ef",
+                "sha256:72ef3925f30e12a184889aac03d77d031056860ccae8a1e519f6cbb742736383",
+                "sha256:819dc789f4498ecc91438a7de64427c73b45035e2e3680c92e18795a839ebb66",
+                "sha256:915ace4ff03fdfff953962fa672d44be269deb2eaf88499a0f8805221bc68c87",
+                "sha256:9311e99228ae10023300ecac05be5a296f60d2fd10fff31cf5c1fa4ca4b1988d",
+                "sha256:974308c58d057a651d182208a484ce80a26dac0caef2895836a92dd6ebd725e0",
+                "sha256:b8b49776299fece66bffaafe357d929ca9451450f5466e997a7285ab0fe28e3b",
+                "sha256:c957b2b4ea88587b46cf49d1dc17681c1e672864fd7af32fc1e9664d572b3458",
+                "sha256:e41a86c6c650bcecc6633ee3180d80a025db041a8e2398dcc059b3afa8382cd4",
+                "sha256:f513588da599943e0cde4e32cc9879e825d58720d6557062d1098c5ad80080e1",
+                "sha256:fba8a281e570adafb79f7755ac8721b6cf1bbf691186a287e990c7929c7692ff"
             ],
             "index": "pypi",
-            "version": "==22.1.0"
+            "version": "==22.10.0"
         },
         "click": {
             "hashes": [
-                "sha256:6a7a62563bbfabfda3a38f3023a1db4a35978c0abd76f6c9605ecd6554d6d9b1",
-                "sha256:8458d7b1287c5fb128c90e23381cf99dcde74beaf6c7ff6384ce84d6fe090adb"
+                "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e",
+                "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==8.0.4"
+            "markers": "python_version >= '3.7'",
+            "version": "==8.1.3"
+        },
+        "dill": {
+            "hashes": [
+                "sha256:33501d03270bbe410c72639b350e941882a8b0fd55357580fbc873fba0c59302",
+                "sha256:d75e41f3eff1eee599d738e76ba8f4ad98ea229db8b085318aa2b3333a208c86"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'",
+            "version": "==0.3.5.1"
         },
         "distlib": {
             "hashes": [
-                "sha256:6564fe0a8f51e734df6333d08b8b94d4ea8ee6b99b5ed50613f731fd4089f34b",
-                "sha256:e4b58818180336dc9c529bfb9a0b58728ffc09ad92027a3f30b7cd91e3458579"
+                "sha256:14bad2d9b04d3a36127ac97f30b12a19268f211063d8f8ee4f47108896e11b46",
+                "sha256:f35c4b692542ca110de7ef0bea44d73981caeb34ca0b9b6b2e6d7790dda8f80e"
             ],
-            "version": "==0.3.4"
+            "version": "==0.3.6"
         },
         "filelock": {
             "hashes": [
-                "sha256:9cd540a9352e432c7246a48fe4e8712b10acb1df2ad1f30e8c070b82ae1fed85",
-                "sha256:f8314284bfffbdcfa0ff3d7992b023d4c628ced6feb957351d4c48d059f56bc0"
+                "sha256:55447caa666f2198c5b6b13a26d2084d26fa5b115c00d065664b2124680c4edc",
+                "sha256:617eb4e5eedc82fc5f47b6d61e4d11cb837c56cb4544e39081099fa17ad109d4"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.6.0"
+            "version": "==3.8.0"
         },
         "iniconfig": {
             "hashes": [
@@ -320,36 +200,41 @@
         },
         "mccabe": {
             "hashes": [
-                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
-                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+                "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325",
+                "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"
             ],
-            "version": "==0.6.1"
+            "markers": "python_version >= '3.6'",
+            "version": "==0.7.0"
         },
         "mypy": {
             "hashes": [
-                "sha256:0038b21890867793581e4cb0d810829f5fd4441aa75796b53033af3aa30430ce",
-                "sha256:1171f2e0859cfff2d366da2c7092b06130f232c636a3f7301e3feb8b41f6377d",
-                "sha256:1b06268df7eb53a8feea99cbfff77a6e2b205e70bf31743e786678ef87ee8069",
-                "sha256:1b65714dc296a7991000b6ee59a35b3f550e0073411ac9d3202f6516621ba66c",
-                "sha256:1bf752559797c897cdd2c65f7b60c2b6969ffe458417b8d947b8340cc9cec08d",
-                "sha256:300717a07ad09525401a508ef5d105e6b56646f7942eb92715a1c8d610149714",
-                "sha256:3c5b42d0815e15518b1f0990cff7a705805961613e701db60387e6fb663fe78a",
-                "sha256:4365c60266b95a3f216a3047f1d8e3f895da6c7402e9e1ddfab96393122cc58d",
-                "sha256:50c7346a46dc76a4ed88f3277d4959de8a2bd0a0fa47fa87a4cde36fe247ac05",
-                "sha256:5b56154f8c09427bae082b32275a21f500b24d93c88d69a5e82f3978018a0266",
-                "sha256:74f7eccbfd436abe9c352ad9fb65872cc0f1f0a868e9d9c44db0893440f0c697",
-                "sha256:7b3f6f557ba4afc7f2ce6d3215d5db279bcf120b3cfd0add20a5d4f4abdae5bc",
-                "sha256:8c11003aaeaf7cc2d0f1bc101c1cc9454ec4cc9cb825aef3cafff8a5fdf4c799",
-                "sha256:8ca7f8c4b1584d63c9a0f827c37ba7a47226c19a23a753d52e5b5eddb201afcd",
-                "sha256:c89702cac5b302f0c5d33b172d2b55b5df2bede3344a2fbed99ff96bddb2cf00",
-                "sha256:d8f1ff62f7a879c9fe5917b3f9eb93a79b78aad47b533911b853a757223f72e7",
-                "sha256:d9d2b84b2007cea426e327d2483238f040c49405a6bf4074f605f0156c91a47a",
-                "sha256:e839191b8da5b4e5d805f940537efcaa13ea5dd98418f06dc585d2891d228cf0",
-                "sha256:f9fe20d0872b26c4bba1c1be02c5340de1019530302cf2dcc85c7f9fc3252ae0",
-                "sha256:ff3bf387c14c805ab1388185dd22d6b210824e164d4bb324b195ff34e322d166"
+                "sha256:1021c241e8b6e1ca5a47e4d52601274ac078a89845cfde66c6d5f769819ffa1d",
+                "sha256:14d53cdd4cf93765aa747a7399f0961a365bcddf7855d9cef6306fa41de01c24",
+                "sha256:175f292f649a3af7082fe36620369ffc4661a71005aa9f8297ea473df5772046",
+                "sha256:26ae64555d480ad4b32a267d10cab7aec92ff44de35a7cd95b2b7cb8e64ebe3e",
+                "sha256:41fd1cf9bc0e1c19b9af13a6580ccb66c381a5ee2cf63ee5ebab747a4badeba3",
+                "sha256:5085e6f442003fa915aeb0a46d4da58128da69325d8213b4b35cc7054090aed5",
+                "sha256:58f27ebafe726a8e5ccb58d896451dd9a662a511a3188ff6a8a6a919142ecc20",
+                "sha256:6389af3e204975d6658de4fb8ac16f58c14e1bacc6142fee86d1b5b26aa52bda",
+                "sha256:724d36be56444f569c20a629d1d4ee0cb0ad666078d59bb84f8f887952511ca1",
+                "sha256:75838c649290d83a2b83a88288c1eb60fe7a05b36d46cbea9d22efc790002146",
+                "sha256:7b35ce03a289480d6544aac85fa3674f493f323d80ea7226410ed065cd46f206",
+                "sha256:85f7a343542dc8b1ed0a888cdd34dca56462654ef23aa673907305b260b3d746",
+                "sha256:86ebe67adf4d021b28c3f547da6aa2cce660b57f0432617af2cca932d4d378a6",
+                "sha256:8ee8c2472e96beb1045e9081de8e92f295b89ac10c4109afdf3a23ad6e644f3e",
+                "sha256:91781eff1f3f2607519c8b0e8518aad8498af1419e8442d5d0afb108059881fc",
+                "sha256:a692a8e7d07abe5f4b2dd32d731812a0175626a90a223d4b58f10f458747dd8a",
+                "sha256:a705a93670c8b74769496280d2fe6cd59961506c64f329bb179970ff1d24f9f8",
+                "sha256:c6e564f035d25c99fd2b863e13049744d96bd1947e3d3d2f16f5828864506763",
+                "sha256:cebca7fd333f90b61b3ef7f217ff75ce2e287482206ef4a8b18f32b49927b1a2",
+                "sha256:d6af646bd46f10d53834a8e8983e130e47d8ab2d4b7a97363e35b24e1d588947",
+                "sha256:e7aeaa763c7ab86d5b66ff27f68493d672e44c8099af636d433a7f3fa5596d40",
+                "sha256:eaa97b9ddd1dd9901a22a879491dbb951b5dec75c3b90032e2baa7336777363b",
+                "sha256:eb7a068e503be3543c4bd329c994103874fa543c1727ba5288393c21d912d795",
+                "sha256:f793e3dd95e166b66d50e7b63e69e58e88643d80a3dcc3bcd81368e0478b089c"
             ],
             "index": "pypi",
-            "version": "==0.931"
+            "version": "==0.982"
         },
         "mypy-extensions": {
             "hashes": [
@@ -368,18 +253,19 @@
         },
         "pathspec": {
             "hashes": [
-                "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a",
-                "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"
+                "sha256:46846318467efc4556ccfd27816e004270a9eeeeb4d062ce5e6fc7a87c573f93",
+                "sha256:7ace6161b621d31e7902eb6b5ae148d12cfd23f4a249b9ffb6b9fee12084323d"
             ],
-            "version": "==0.9.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==0.10.1"
         },
         "platformdirs": {
             "hashes": [
-                "sha256:7535e70dfa32e84d4b34996ea99c5e432fa29a708d0f4e394bbcb2a8faa4f16d",
-                "sha256:bcae7cab893c2d310a711b70b24efb93334febe65f8de776ee320b517471e227"
+                "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788",
+                "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.5.1"
+            "version": "==2.5.2"
         },
         "pluggy": {
             "hashes": [
@@ -399,35 +285,35 @@
         },
         "pycodestyle": {
             "hashes": [
-                "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20",
-                "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"
+                "sha256:2c9607871d58c76354b697b42f5d57e1ada7d261c261efac224b664affdc5785",
+                "sha256:d1735fc58b418fd7c5f658d28d943854f8a849b01a5d0a1e6f3f3fdd0166804b"
             ],
             "index": "pypi",
-            "version": "==2.8.0"
+            "version": "==2.9.1"
         },
         "pylint": {
             "hashes": [
-                "sha256:9d945a73640e1fec07ee34b42f5669b770c759acd536ec7b16d7e4b87a9c9ff9",
-                "sha256:daabda3f7ed9d1c60f52d563b1b854632fd90035bcf01443e234d3dc794e3b74"
+                "sha256:5fdfd44af182866999e6123139d265334267339f29961f00c89783155eacc60b",
+                "sha256:7f6aad1d8d50807f7bc64f89ac75256a9baf8e6ed491cc9bc65592bc3f462cf1"
             ],
             "index": "pypi",
-            "version": "==2.12.2"
+            "version": "==2.15.3"
         },
         "pyparsing": {
             "hashes": [
-                "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea",
-                "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"
+                "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb",
+                "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==3.0.7"
+            "markers": "python_full_version >= '3.6.8'",
+            "version": "==3.0.9"
         },
         "pytest": {
             "hashes": [
-                "sha256:9ce3ff477af913ecf6321fe337b93a2c0dcf2a0a1439c43f5452112c1e4280db",
-                "sha256:e30905a0c131d3d94b89624a1cc5afec3e0ba2fbdb151867d8e0ebd49850f171"
+                "sha256:1377bda3466d70b55e3f5cecfa55bb7cfcf219c7964629b967c37cf0bda818b7",
+                "sha256:4f365fec2dff9c1162f834d9f18af1ba13062db0c708bf7b946f8a5c76180c39"
             ],
             "index": "pypi",
-            "version": "==7.0.1"
+            "version": "==7.1.3"
         },
         "pytest-html": {
             "hashes": [
@@ -439,22 +325,31 @@
         },
         "pytest-metadata": {
             "hashes": [
-                "sha256:576055b8336dd4a9006dd2a47615f76f2f8c30ab12b1b1c039d99e834583523f",
-                "sha256:71b506d49d34e539cc3cfdb7ce2c5f072bea5c953320002c95968e0238f8ecf1"
+                "sha256:39261ee0086f17649b180baf2a8633e1922a4c4b6fcc28a2de7d8127a82541bf",
+                "sha256:fcd2f416f15be295943527b3c8ba16a44ae5a7141939c90c3dc5ce9d167cf2a5"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.11.0"
+            "markers": "python_version >= '3.7' and python_version < '4.0'",
+            "version": "==2.0.2"
         },
         "pytest-pylint": {
             "hashes": [
-                "sha256:790c7a8019fab08e59bd3812db1657a01995a975af8b1c6ce95b9aa39d61da27",
-                "sha256:b63aaf8b80ff33c8ceaa7f68323ed04102c7790093ccf6bdb261a4c2dc6fd564"
+                "sha256:b51d3f93bed9c192e2b046f16520981bee5abe7bd61b070306e7ee685219fdd3",
+                "sha256:d88e83c1023c641548a9ec3567707ceee7616632a986af133426d4a74d066932"
             ],
             "index": "pypi",
-            "version": "==0.18.0"
+            "version": "==0.19.0"
+        },
+        "pytoolconfig": {
+            "hashes": [
+                "sha256:2512a1f261a40e73cef2e58e786184261b60c802ae7ed01249342b1949ec3aa2",
+                "sha256:825d97b052e58b609c2684b04efeb543075588d33a4916a6dc2ae39676458c7d"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.2.2"
         },
         "pyyaml": {
             "hashes": [
+                "sha256:01b45c0191e6d66c470b6cf1b9531a771a83c1c4208272ead47a3ae4f2f603bf",
                 "sha256:0283c35a6a9fbf047493e3a0ce8d79ef5030852c51e9d911a27badfde0605293",
                 "sha256:055d937d65826939cb044fc8c9b08889e8c743fdc6a32b33e2390f66013e449b",
                 "sha256:07751360502caac1c067a8132d150cf3d61339af5691fe9e87803040dbc5db57",
@@ -466,26 +361,32 @@
                 "sha256:277a0ef2981ca40581a47093e9e2d13b3f1fbbeffae064c1d21bfceba2030287",
                 "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513",
                 "sha256:40527857252b61eacd1d9af500c3337ba8deb8fc298940291486c465c8b46ec0",
+                "sha256:432557aa2c09802be39460360ddffd48156e30721f5e8d917f01d31694216782",
                 "sha256:473f9edb243cb1935ab5a084eb238d842fb8f404ed2193a915d1784b5a6b5fc0",
                 "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92",
                 "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f",
                 "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2",
                 "sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc",
+                "sha256:81957921f441d50af23654aa6c5e5eaf9b06aba7f0a19c18a538dc7ef291c5a1",
                 "sha256:819b3830a1543db06c4d4b865e70ded25be52a2e0631ccd2f6a47a2822f2fd7c",
                 "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86",
                 "sha256:98c4d36e99714e55cfbaaee6dd5badbc9a1ec339ebfc3b1f52e293aee6bb71a4",
                 "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c",
                 "sha256:9fa600030013c4de8165339db93d182b9431076eb98eb40ee068700c9c813e34",
                 "sha256:a80a78046a72361de73f8f395f1f1e49f956c6be882eed58505a15f3e430962b",
+                "sha256:afa17f5bc4d1b10afd4466fd3a44dc0e245382deca5b3c353d8b757f9e3ecb8d",
                 "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c",
                 "sha256:b5b9eccad747aabaaffbc6064800670f0c297e52c12754eb1d976c57e4f74dcb",
+                "sha256:bfaef573a63ba8923503d27530362590ff4f576c626d86a9fed95822a8255fd7",
                 "sha256:c5687b8d43cf58545ade1fe3e055f70eac7a5a1a0bf42824308d868289a95737",
                 "sha256:cba8c411ef271aa037d7357a2bc8f9ee8b58b9965831d9e51baf703280dc73d3",
                 "sha256:d15a181d1ecd0d4270dc32edb46f7cb7733c7c508857278d3d378d14d606db2d",
+                "sha256:d4b0ba9512519522b118090257be113b9468d804b19d63c71dbcf4a48fa32358",
                 "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53",
                 "sha256:d4eccecf9adf6fbcc6861a38015c2a64f38b9d94838ac1810a9023a0609e1b78",
                 "sha256:d67d839ede4ed1b28a4e8909735fc992a923cdb84e618544973d7dfc71540803",
                 "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a",
+                "sha256:dbad0e9d368bb989f4515da330b88a057617d16b6a8245084f1b05400f24609f",
                 "sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174",
                 "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"
             ],
@@ -494,19 +395,19 @@
         },
         "rope": {
             "hashes": [
-                "sha256:edf2ed3c9b35a8814752ffd3ea55b293c791e5087e252461de898e953cf9c146",
-                "sha256:f87662c565086d660fc855cc07f37820267876634c3e9e51bddb32ff51547268"
+                "sha256:4e8ede637d8f43eb83847ef9ea7edbf4ceb9d641deea592ed38a8875cde64265",
+                "sha256:f0c82bd7167c2926339c6f0d9ecf7c93d6866cbe380c78639fa1bc4ac037c097"
             ],
             "index": "pypi",
-            "version": "==0.23.0"
+            "version": "==1.3.0"
         },
         "setuptools": {
             "hashes": [
-                "sha256:2347b2b432c891a863acadca2da9ac101eae6169b1d3dfee2ec605ecd50dbfe5",
-                "sha256:e4f30b9f84e5ab3decf945113119649fec09c1fc3507c6ebffec75646c56e62b"
+                "sha256:1b6bdc6161661409c5f21508763dc63ab20a9ac2f8ba20029aaaa7fdb9118012",
+                "sha256:3050e338e5871e70c72983072fe34f6032ae1cdeeeb67338199c2f74e083a80e"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==60.9.3"
+            "index": "pypi",
+            "version": "==65.4.1"
         },
         "six": {
             "hashes": [
@@ -529,55 +430,63 @@
                 "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
                 "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_full_version < '3.11.0a7'",
             "version": "==2.0.1"
+        },
+        "tomlkit": {
+            "hashes": [
+                "sha256:571854ebbb5eac89abcb4a2e47d7ea27b89bf29e09c35395da6f03dd4ae23d1c",
+                "sha256:f2ef9da9cef846ee027947dc99a45d6b68a63b0ebc21944649505bf2e8bc5fe7"
+            ],
+            "markers": "python_version >= '3.6' and python_version < '4.0'",
+            "version": "==0.11.5"
         },
         "tox": {
             "hashes": [
-                "sha256:67e0e32c90e278251fea45b696d0fef3879089ccbe979b0c556d35d5a70e2993",
-                "sha256:be3362472a33094bce26727f5f771ca0facf6dafa217f65875314e9a6600c95c"
+                "sha256:44f3c347c68c2c68799d7d44f1808f9d396fc8a1a500cbc624253375c7ae107e",
+                "sha256:bf037662d7c740d15c9924ba23bb3e587df20598697bb985ac2b49bdc2d847f6"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==3.24.5"
+            "index": "pypi",
+            "version": "==3.26.0"
         },
         "types-pyyaml": {
             "hashes": [
-                "sha256:6252f62d785e730e454dfa0c9f0fb99d8dae254c5c3c686903cf878ea27c04b7",
-                "sha256:693b01c713464a6851f36ff41077f8adbc6e355eda929addfb4a97208aea9b4b"
+                "sha256:29228db9f82df4f1b7febee06bbfb601677882e98a3da98132e31c6874163e15",
+                "sha256:f6f350418125872f3f0409d96a62a5a5ceb45231af5cc07ee0034ec48a3c82fa"
             ],
             "index": "pypi",
-            "version": "==6.0.4"
+            "version": "==6.0.12"
         },
         "types-requests": {
             "hashes": [
-                "sha256:506279bad570c7b4b19ac1f22e50146538befbe0c133b2cea66a9b04a533a859",
-                "sha256:6a7ed24b21780af4a5b5e24c310b2cd885fb612df5fd95584d03d87e5f2a195a"
+                "sha256:14941f8023a80b16441b3b46caffcbfce5265fd14555844d6029697824b5a2ef",
+                "sha256:fdcd7bd148139fb8eef72cf4a41ac7273872cad9e6ada14b11ff5dfdeee60ed3"
             ],
             "index": "pypi",
-            "version": "==2.27.11"
+            "version": "==2.28.11.2"
         },
         "types-urllib3": {
             "hashes": [
-                "sha256:a26898f530e6c3f43f25b907f2b884486868ffd56a9faa94cbf9b3eb6e165d6a",
-                "sha256:d755278d5ecd7a7a6479a190e54230f241f1a99c19b81518b756b19dc69e518c"
+                "sha256:5aef0e663724eef924afa8b320b62ffef2c1736c1fa6caecfc9bc6c8ae2c3def",
+                "sha256:c1d78cef7bd581e162e46c20a57b2e1aa6ebecdcf01fd0713bb90978ff3e3427"
             ],
-            "version": "==1.26.10"
+            "version": "==1.26.25"
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42",
-                "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"
+                "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa",
+                "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"
             ],
             "markers": "python_version < '3.10'",
-            "version": "==4.1.1"
+            "version": "==4.4.0"
         },
         "virtualenv": {
             "hashes": [
-                "sha256:01f5f80744d24a3743ce61858123488e91cb2dd1d3bdf92adaf1bba39ffdedf0",
-                "sha256:e7b34c9474e6476ee208c43a4d9ac1510b041c68347eabfe9a9ea0c86aa0a46b"
+                "sha256:227ea1b9994fdc5ea31977ba3383ef296d7472ea85be9d6732e42a91c04e80da",
+                "sha256:d07dfc5df5e4e0dbc92862350ad87a36ed505b978f6c39609dc489eadd5b0d27"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==20.13.2"
+            "markers": "python_version >= '3.6'",
+            "version": "==20.16.5"
         },
         "wheel": {
             "hashes": [
@@ -589,60 +498,73 @@
         },
         "wrapt": {
             "hashes": [
-                "sha256:086218a72ec7d986a3eddb7707c8c4526d677c7b35e355875a0fe2918b059179",
-                "sha256:0877fe981fd76b183711d767500e6b3111378ed2043c145e21816ee589d91096",
-                "sha256:0a017a667d1f7411816e4bf214646d0ad5b1da2c1ea13dec6c162736ff25a374",
-                "sha256:0cb23d36ed03bf46b894cfec777eec754146d68429c30431c99ef28482b5c1df",
-                "sha256:1fea9cd438686e6682271d36f3481a9f3636195578bab9ca3382e2f5f01fc185",
-                "sha256:220a869982ea9023e163ba915077816ca439489de6d2c09089b219f4e11b6785",
-                "sha256:25b1b1d5df495d82be1c9d2fad408f7ce5ca8a38085e2da41bb63c914baadff7",
-                "sha256:2dded5496e8f1592ec27079b28b6ad2a1ef0b9296d270f77b8e4a3a796cf6909",
-                "sha256:2ebdde19cd3c8cdf8df3fc165bc7827334bc4e353465048b36f7deeae8ee0918",
-                "sha256:43e69ffe47e3609a6aec0fe723001c60c65305784d964f5007d5b4fb1bc6bf33",
-                "sha256:46f7f3af321a573fc0c3586612db4decb7eb37172af1bc6173d81f5b66c2e068",
-                "sha256:47f0a183743e7f71f29e4e21574ad3fa95676136f45b91afcf83f6a050914829",
-                "sha256:498e6217523111d07cd67e87a791f5e9ee769f9241fcf8a379696e25806965af",
-                "sha256:4b9c458732450ec42578b5642ac53e312092acf8c0bfce140ada5ca1ac556f79",
-                "sha256:51799ca950cfee9396a87f4a1240622ac38973b6df5ef7a41e7f0b98797099ce",
-                "sha256:5601f44a0f38fed36cc07db004f0eedeaadbdcec90e4e90509480e7e6060a5bc",
-                "sha256:5f223101f21cfd41deec8ce3889dc59f88a59b409db028c469c9b20cfeefbe36",
-                "sha256:610f5f83dd1e0ad40254c306f4764fcdc846641f120c3cf424ff57a19d5f7ade",
-                "sha256:6a03d9917aee887690aa3f1747ce634e610f6db6f6b332b35c2dd89412912bca",
-                "sha256:705e2af1f7be4707e49ced9153f8d72131090e52be9278b5dbb1498c749a1e32",
-                "sha256:766b32c762e07e26f50d8a3468e3b4228b3736c805018e4b0ec8cc01ecd88125",
-                "sha256:77416e6b17926d953b5c666a3cb718d5945df63ecf922af0ee576206d7033b5e",
-                "sha256:778fd096ee96890c10ce96187c76b3e99b2da44e08c9e24d5652f356873f6709",
-                "sha256:78dea98c81915bbf510eb6a3c9c24915e4660302937b9ae05a0947164248020f",
-                "sha256:7dd215e4e8514004c8d810a73e342c536547038fb130205ec4bba9f5de35d45b",
-                "sha256:7dde79d007cd6dfa65afe404766057c2409316135cb892be4b1c768e3f3a11cb",
-                "sha256:81bd7c90d28a4b2e1df135bfbd7c23aee3050078ca6441bead44c42483f9ebfb",
-                "sha256:85148f4225287b6a0665eef08a178c15097366d46b210574a658c1ff5b377489",
-                "sha256:865c0b50003616f05858b22174c40ffc27a38e67359fa1495605f96125f76640",
-                "sha256:87883690cae293541e08ba2da22cacaae0a092e0ed56bbba8d018cc486fbafbb",
-                "sha256:8aab36778fa9bba1a8f06a4919556f9f8c7b33102bd71b3ab307bb3fecb21851",
-                "sha256:8c73c1a2ec7c98d7eaded149f6d225a692caa1bd7b2401a14125446e9e90410d",
-                "sha256:936503cb0a6ed28dbfa87e8fcd0a56458822144e9d11a49ccee6d9a8adb2ac44",
-                "sha256:944b180f61f5e36c0634d3202ba8509b986b5fbaf57db3e94df11abee244ba13",
-                "sha256:96b81ae75591a795d8c90edc0bfaab44d3d41ffc1aae4d994c5aa21d9b8e19a2",
-                "sha256:981da26722bebb9247a0601e2922cedf8bb7a600e89c852d063313102de6f2cb",
-                "sha256:ae9de71eb60940e58207f8e71fe113c639da42adb02fb2bcbcaccc1ccecd092b",
-                "sha256:b73d4b78807bd299b38e4598b8e7bd34ed55d480160d2e7fdaabd9931afa65f9",
-                "sha256:d4a5f6146cfa5c7ba0134249665acd322a70d1ea61732723c7d3e8cc0fa80755",
-                "sha256:dd91006848eb55af2159375134d724032a2d1d13bcc6f81cd8d3ed9f2b8e846c",
-                "sha256:e05e60ff3b2b0342153be4d1b597bbcfd8330890056b9619f4ad6b8d5c96a81a",
-                "sha256:e6906d6f48437dfd80464f7d7af1740eadc572b9f7a4301e7dd3d65db285cacf",
-                "sha256:e92d0d4fa68ea0c02d39f1e2f9cb5bc4b4a71e8c442207433d8db47ee79d7aa3",
-                "sha256:e94b7d9deaa4cc7bac9198a58a7240aaf87fe56c6277ee25fa5b3aa1edebd229",
-                "sha256:ea3e746e29d4000cd98d572f3ee2a6050a4f784bb536f4ac1f035987fc1ed83e",
-                "sha256:ec7e20258ecc5174029a0f391e1b948bf2906cd64c198a9b8b281b811cbc04de",
-                "sha256:ec9465dd69d5657b5d2fa6133b3e1e989ae27d29471a672416fd729b429eb554",
-                "sha256:f122ccd12fdc69628786d0c947bdd9cb2733be8f800d88b5a37c57f1f1d73c10",
-                "sha256:f99c0489258086308aad4ae57da9e8ecf9e1f3f30fa35d5e170b4d4896554d80",
-                "sha256:f9c51d9af9abb899bd34ace878fbec8bf357b3194a10c4e8e0a25512826ef056",
-                "sha256:fd76c47f20984b43d93de9a82011bb6e5f8325df6c9ed4d8310029a55fa361ea"
+                "sha256:00b6d4ea20a906c0ca56d84f93065b398ab74b927a7a3dbd470f6fc503f95dc3",
+                "sha256:01c205616a89d09827986bc4e859bcabd64f5a0662a7fe95e0d359424e0e071b",
+                "sha256:02b41b633c6261feff8ddd8d11c711df6842aba629fdd3da10249a53211a72c4",
+                "sha256:07f7a7d0f388028b2df1d916e94bbb40624c59b48ecc6cbc232546706fac74c2",
+                "sha256:11871514607b15cfeb87c547a49bca19fde402f32e2b1c24a632506c0a756656",
+                "sha256:1b376b3f4896e7930f1f772ac4b064ac12598d1c38d04907e696cc4d794b43d3",
+                "sha256:21ac0156c4b089b330b7666db40feee30a5d52634cc4560e1905d6529a3897ff",
+                "sha256:257fd78c513e0fb5cdbe058c27a0624c9884e735bbd131935fd49e9fe719d310",
+                "sha256:2b39d38039a1fdad98c87279b48bc5dce2c0ca0d73483b12cb72aa9609278e8a",
+                "sha256:2cf71233a0ed05ccdabe209c606fe0bac7379fdcf687f39b944420d2a09fdb57",
+                "sha256:2fe803deacd09a233e4762a1adcea5db5d31e6be577a43352936179d14d90069",
+                "sha256:3232822c7d98d23895ccc443bbdf57c7412c5a65996c30442ebe6ed3df335383",
+                "sha256:34aa51c45f28ba7f12accd624225e2b1e5a3a45206aa191f6f9aac931d9d56fe",
+                "sha256:36f582d0c6bc99d5f39cd3ac2a9062e57f3cf606ade29a0a0d6b323462f4dd87",
+                "sha256:380a85cf89e0e69b7cfbe2ea9f765f004ff419f34194018a6827ac0e3edfed4d",
+                "sha256:40e7bc81c9e2b2734ea4bc1aceb8a8f0ceaac7c5299bc5d69e37c44d9081d43b",
+                "sha256:43ca3bbbe97af00f49efb06e352eae40434ca9d915906f77def219b88e85d907",
+                "sha256:4fcc4649dc762cddacd193e6b55bc02edca674067f5f98166d7713b193932b7f",
+                "sha256:5a0f54ce2c092aaf439813735584b9537cad479575a09892b8352fea5e988dc0",
+                "sha256:5a9a0d155deafd9448baff28c08e150d9b24ff010e899311ddd63c45c2445e28",
+                "sha256:5b02d65b9ccf0ef6c34cba6cf5bf2aab1bb2f49c6090bafeecc9cd81ad4ea1c1",
+                "sha256:60db23fa423575eeb65ea430cee741acb7c26a1365d103f7b0f6ec412b893853",
+                "sha256:642c2e7a804fcf18c222e1060df25fc210b9c58db7c91416fb055897fc27e8cc",
+                "sha256:6a9a25751acb379b466ff6be78a315e2b439d4c94c1e99cb7266d40a537995d3",
+                "sha256:6b1a564e6cb69922c7fe3a678b9f9a3c54e72b469875aa8018f18b4d1dd1adf3",
+                "sha256:6d323e1554b3d22cfc03cd3243b5bb815a51f5249fdcbb86fda4bf62bab9e164",
+                "sha256:6e743de5e9c3d1b7185870f480587b75b1cb604832e380d64f9504a0535912d1",
+                "sha256:709fe01086a55cf79d20f741f39325018f4df051ef39fe921b1ebe780a66184c",
+                "sha256:7b7c050ae976e286906dd3f26009e117eb000fb2cf3533398c5ad9ccc86867b1",
+                "sha256:7d2872609603cb35ca513d7404a94d6d608fc13211563571117046c9d2bcc3d7",
+                "sha256:7ef58fb89674095bfc57c4069e95d7a31cfdc0939e2a579882ac7d55aadfd2a1",
+                "sha256:80bb5c256f1415f747011dc3604b59bc1f91c6e7150bd7db03b19170ee06b320",
+                "sha256:81b19725065dcb43df02b37e03278c011a09e49757287dca60c5aecdd5a0b8ed",
+                "sha256:833b58d5d0b7e5b9832869f039203389ac7cbf01765639c7309fd50ef619e0b1",
+                "sha256:88bd7b6bd70a5b6803c1abf6bca012f7ed963e58c68d76ee20b9d751c74a3248",
+                "sha256:8ad85f7f4e20964db4daadcab70b47ab05c7c1cf2a7c1e51087bfaa83831854c",
+                "sha256:8c0ce1e99116d5ab21355d8ebe53d9460366704ea38ae4d9f6933188f327b456",
+                "sha256:8d649d616e5c6a678b26d15ece345354f7c2286acd6db868e65fcc5ff7c24a77",
+                "sha256:903500616422a40a98a5a3c4ff4ed9d0066f3b4c951fa286018ecdf0750194ef",
+                "sha256:9736af4641846491aedb3c3f56b9bc5568d92b0692303b5a305301a95dfd38b1",
+                "sha256:988635d122aaf2bdcef9e795435662bcd65b02f4f4c1ae37fbee7401c440b3a7",
+                "sha256:9cca3c2cdadb362116235fdbd411735de4328c61425b0aa9f872fd76d02c4e86",
+                "sha256:9e0fd32e0148dd5dea6af5fee42beb949098564cc23211a88d799e434255a1f4",
+                "sha256:9f3e6f9e05148ff90002b884fbc2a86bd303ae847e472f44ecc06c2cd2fcdb2d",
+                "sha256:a85d2b46be66a71bedde836d9e41859879cc54a2a04fad1191eb50c2066f6e9d",
+                "sha256:a9a52172be0b5aae932bef82a79ec0a0ce87288c7d132946d645eba03f0ad8a8",
+                "sha256:aa31fdcc33fef9eb2552cbcbfee7773d5a6792c137b359e82879c101e98584c5",
+                "sha256:b014c23646a467558be7da3d6b9fa409b2c567d2110599b7cf9a0c5992b3b471",
+                "sha256:b21bb4c09ffabfa0e85e3a6b623e19b80e7acd709b9f91452b8297ace2a8ab00",
+                "sha256:b5901a312f4d14c59918c221323068fad0540e34324925c8475263841dbdfe68",
+                "sha256:b9b7a708dd92306328117d8c4b62e2194d00c365f18eff11a9b53c6f923b01e3",
+                "sha256:d1967f46ea8f2db647c786e78d8cc7e4313dbd1b0aca360592d8027b8508e24d",
+                "sha256:d52a25136894c63de15a35bc0bdc5adb4b0e173b9c0d07a2be9d3ca64a332735",
+                "sha256:d77c85fedff92cf788face9bfa3ebaa364448ebb1d765302e9af11bf449ca36d",
+                "sha256:d79d7d5dc8a32b7093e81e97dad755127ff77bcc899e845f41bf71747af0c569",
+                "sha256:dbcda74c67263139358f4d188ae5faae95c30929281bc6866d00573783c422b7",
+                "sha256:ddaea91abf8b0d13443f6dac52e89051a5063c7d014710dcb4d4abb2ff811a59",
+                "sha256:dee0ce50c6a2dd9056c20db781e9c1cfd33e77d2d569f5d1d9321c641bb903d5",
+                "sha256:dee60e1de1898bde3b238f18340eec6148986da0455d8ba7848d50470a7a32fb",
+                "sha256:e2f83e18fe2f4c9e7db597e988f72712c0c3676d337d8b101f6758107c42425b",
+                "sha256:e3fb1677c720409d5f671e39bac6c9e0e422584e5f518bfd50aa4cbbea02433f",
+                "sha256:ee2b1b1769f6707a8a445162ea16dddf74285c3964f605877a20e38545c3c462",
+                "sha256:ee6acae74a2b91865910eef5e7de37dc6895ad96fa23603d1d27ea69df545015",
+                "sha256:ef3f72c9666bba2bab70d2a8b79f2c6d2c1a42a7f7e2b0ec83bb2f9e383950af"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==1.13.3"
+            "markers": "python_version < '3.11'",
+            "version": "==1.14.1"
         }
     }
 }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
`requests` provides a convenient Session object that allows headers to be shared across all requests made with a given session. `conjure-python` initializes all services with a requests.Session() object, but also created a non-optional `auth-header` field for all generated methods that require header authentication. Even if the auth header is specified in the Session object, it will not be respected and must be provided for every method call. This PR modifies the generation code to ensure that headers are optional, and will override the Service._request_session.headers object only if specified

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Required headers are now optional when calling methods and can instead be provided in the `requests.Session.headers` dict. If headers are provided in the method, they will override the session headers.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
The exception raised for missing required headers will change from a `TypeError` to the exception raised by requests
