### PR TITLE
Use type_of_union to determine the union variant

### DIFF
--- a/changelog/@unreleased/fix-windows-batch-scripts.v2.yml
+++ b/changelog/@unreleased/fix-windows-batch-scripts.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Use type_of_union to determine the union variant if parameter is passed in.
+  links:
+    - https://github.com/palantir/conjure-java/pull/681

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
@@ -125,7 +125,7 @@ public interface UnionSnippet extends PythonSnippet {
                         "%s: Optional[%s] = None,",
                         PythonIdentifierSanitizer.sanitize(option.attributeName()), option.myPyType()));
             }
-            poetWriter.writeIndentedLine("type_of_union: str");
+            poetWriter.writeIndentedLine("type_of_union: str = \"\"");
             poetWriter.writeIndentedLine(") -> None:");
             poetWriter.decreaseIndent();
 

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
@@ -125,7 +125,7 @@ public interface UnionSnippet extends PythonSnippet {
                         "%s: Optional[%s] = None,",
                         PythonIdentifierSanitizer.sanitize(option.attributeName()), option.myPyType()));
             }
-            poetWriter.writeIndentedLine("type_of_union: str = \"\"");
+            poetWriter.writeIndentedLine("type_of_union: Optional[str] = None");
             poetWriter.writeIndentedLine(") -> None:");
             poetWriter.decreaseIndent();
 
@@ -178,7 +178,7 @@ public interface UnionSnippet extends PythonSnippet {
                     "raise ValueError('{} is not an instance of %s'.format(visitor.__class__.__name__))", visitorName);
             poetWriter.decreaseIndent();
             options().forEach(option -> {
-                poetWriter.writeIndentedLine("if self.%s is not None:", propertyName(option));
+                poetWriter.writeIndentedLine("if self._type == '%s':", parameterName(option));
                 poetWriter.increaseIndent();
                 poetWriter.writeIndentedLine(
                         "return visitor.%s(self.%s)", visitorMethodName(option), propertyName(option));

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
@@ -137,7 +137,7 @@ public interface UnionSnippet extends PythonSnippet {
                 poetWriter.writeIndentedLine("if type_of_union == '%s':", parameterName(option));
                 poetWriter.increaseIndent();
                
-                if (parameterName(option) != "optional" && parameterName(option) != "collection") {
+                if (!parameterName(option).equals("optional") && !parameterName(option).equals("collection")) {
                     poetWriter.writeIndentedLine("if %s is None:", parameterName(option));
                     poetWriter.increaseIndent();
                     poetWriter.writeIndentedLine("raise ValueError('a union value must not be None')");

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
@@ -123,8 +123,7 @@ public interface UnionSnippet extends PythonSnippet {
 
                 poetWriter.writeIndentedLine(String.format(
                         "%s: Optional[%s] = None,",
-                        PythonIdentifierSanitizer.sanitize(option.attributeName()),
-                        option.myPyType()));
+                        PythonIdentifierSanitizer.sanitize(option.attributeName()), option.myPyType()));
             }
             poetWriter.writeIndentedLine("type_of_union: str");
             poetWriter.writeIndentedLine(") -> None:");
@@ -135,7 +134,8 @@ public interface UnionSnippet extends PythonSnippet {
                 poetWriter.writeIndentedLine("if type_of_union == '%s':", parameterName(option));
                 poetWriter.increaseIndent();
 
-                if (!parameterName(option).equals("optional") && !parameterName(option).equals("collection")) {
+                if (!parameterName(option).equals("optional")
+                        && !parameterName(option).equals("collection")) {
                     poetWriter.writeIndentedLine("if %s is None:", parameterName(option));
                     poetWriter.increaseIndent();
                     poetWriter.writeIndentedLine("raise ValueError('a union value must not be None')");

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
@@ -16,7 +16,6 @@
 
 package com.palantir.conjure.python.poet;
 
-import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.palantir.conjure.python.processors.PythonIdentifierSanitizer;
@@ -24,7 +23,6 @@ import com.palantir.conjure.python.types.ImportTypeVisitor;
 import com.palantir.conjure.spec.Documentation;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -136,7 +134,7 @@ public interface UnionSnippet extends PythonSnippet {
             options().forEach(option -> {
                 poetWriter.writeIndentedLine("if type_of_union == '%s':", parameterName(option));
                 poetWriter.increaseIndent();
-               
+
                 if (!parameterName(option).equals("optional") && !parameterName(option).equals("collection")) {
                     poetWriter.writeIndentedLine("if %s is None:", parameterName(option));
                     poetWriter.increaseIndent();

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
@@ -134,8 +134,7 @@ public interface UnionSnippet extends PythonSnippet {
                 poetWriter.writeIndentedLine("if type_of_union == '%s':", parameterName(option));
                 poetWriter.increaseIndent();
 
-                if (!parameterName(option).equals("optional")
-                        && !parameterName(option).equals("collection")) {
+                if (!parameterName(option).equals("optional")) {
                     poetWriter.writeIndentedLine("if %s is None:", parameterName(option));
                     poetWriter.increaseIndent();
                     poetWriter.writeIndentedLine("raise ValueError('a union value must not be None')");
@@ -178,7 +177,13 @@ public interface UnionSnippet extends PythonSnippet {
                     "raise ValueError('{} is not an instance of %s'.format(visitor.__class__.__name__))", visitorName);
             poetWriter.decreaseIndent();
             options().forEach(option -> {
-                poetWriter.writeIndentedLine("if self._type == '%s':", parameterName(option));
+                if (parameterName(option).equals("optional")) {
+                    poetWriter.writeIndentedLine("if self._type == '%s':", parameterName(option));
+                } else {
+                    poetWriter.writeIndentedLine(
+                            "if self._type == '%s' and self.%s is not None:",
+                            parameterName(option), propertyName(option));
+                }
                 poetWriter.increaseIndent();
                 poetWriter.writeIndentedLine(
                         "return visitor.%s(self.%s)", visitorMethodName(option), propertyName(option));

--- a/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
@@ -1122,7 +1122,7 @@ class product_OptionsUnion(ConjureUnionType):
     def __init__(
             self,
             options: Optional[str] = None,
-            type_of_union: str = ""
+            type_of_union: Optional[str] = None
             ) -> None:
         if type_of_union == 'options':
             if options is None:
@@ -1137,7 +1137,7 @@ class product_OptionsUnion(ConjureUnionType):
     def accept(self, visitor) -> Any:
         if not isinstance(visitor, product_OptionsUnionVisitor):
             raise ValueError('{} is not an instance of product_OptionsUnionVisitor'.format(visitor.__class__.__name__))
-        if self.options is not None:
+        if self._type == 'options':
             return visitor._options(self.options)
 
 
@@ -1413,7 +1413,7 @@ class product_UnionTypeExample(ConjureUnionType):
             new: Optional[int] = None,
             interface: Optional[int] = None,
             property: Optional[int] = None,
-            type_of_union: str = ""
+            type_of_union: Optional[str] = None
             ) -> None:
         if type_of_union == 'string_example':
             if string_example is None:
@@ -1494,21 +1494,21 @@ class product_UnionTypeExample(ConjureUnionType):
     def accept(self, visitor) -> Any:
         if not isinstance(visitor, product_UnionTypeExampleVisitor):
             raise ValueError('{} is not an instance of product_UnionTypeExampleVisitor'.format(visitor.__class__.__name__))
-        if self.string_example is not None:
+        if self._type == 'string_example':
             return visitor._string_example(self.string_example)
-        if self.set is not None:
+        if self._type == 'set':
             return visitor._set(self.set)
-        if self.this_field_is_an_integer is not None:
+        if self._type == 'this_field_is_an_integer':
             return visitor._this_field_is_an_integer(self.this_field_is_an_integer)
-        if self.also_an_integer is not None:
+        if self._type == 'also_an_integer':
             return visitor._also_an_integer(self.also_an_integer)
-        if self.if_ is not None:
+        if self._type == 'if_':
             return visitor._if(self.if_)
-        if self.new is not None:
+        if self._type == 'new':
             return visitor._new(self.new)
-        if self.interface is not None:
+        if self._type == 'interface':
             return visitor._interface(self.interface)
-        if self.property is not None:
+        if self._type == 'property':
             return visitor._property(self.property)
 
 
@@ -1753,7 +1753,7 @@ class with_imports_UnionWithImports(ConjureUnionType):
             self,
             string: Optional[str] = None,
             imported: Optional["product_AnyMapExample"] = None,
-            type_of_union: str = ""
+            type_of_union: Optional[str] = None
             ) -> None:
         if type_of_union == 'string':
             if string is None:
@@ -1777,9 +1777,9 @@ class with_imports_UnionWithImports(ConjureUnionType):
     def accept(self, visitor) -> Any:
         if not isinstance(visitor, with_imports_UnionWithImportsVisitor):
             raise ValueError('{} is not an instance of with_imports_UnionWithImportsVisitor'.format(visitor.__class__.__name__))
-        if self.string is not None:
+        if self._type == 'string':
             return visitor._string(self.string)
-        if self.imported is not None:
+        if self._type == 'imported':
             return visitor._imported(self.imported)
 
 

--- a/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
@@ -1124,7 +1124,15 @@ class product_OptionsUnion(ConjureUnionType):
             options: Optional[str] = None,
             type_of_union: Optional[str] = None
             ) -> None:
-        if type_of_union == 'options':
+        if type_of_union is None:
+            if (options is not None) != 1:
+                raise ValueError('a union must contain a single member')
+
+            if options is not None:
+                self._options_ = options
+                self._type = 'options'
+
+        elif type_of_union == 'options':
             if options is None:
                 raise ValueError('a union value must not be None')
             self._options_ = options
@@ -1415,42 +1423,71 @@ class product_UnionTypeExample(ConjureUnionType):
             property: Optional[int] = None,
             type_of_union: Optional[str] = None
             ) -> None:
-        if type_of_union == 'string_example':
+        if type_of_union is None:
+            if (string_example is not None) + (set is not None) + (this_field_is_an_integer is not None) + (also_an_integer is not None) + (if_ is not None) + (new is not None) + (interface is not None) + (property is not None) != 1:
+                raise ValueError('a union must contain a single member')
+
+            if string_example is not None:
+                self._string_example = string_example
+                self._type = 'stringExample'
+            if set is not None:
+                self._set = set
+                self._type = 'set'
+            if this_field_is_an_integer is not None:
+                self._this_field_is_an_integer = this_field_is_an_integer
+                self._type = 'thisFieldIsAnInteger'
+            if also_an_integer is not None:
+                self._also_an_integer = also_an_integer
+                self._type = 'alsoAnInteger'
+            if if_ is not None:
+                self._if_ = if_
+                self._type = 'if'
+            if new is not None:
+                self._new = new
+                self._type = 'new'
+            if interface is not None:
+                self._interface = interface
+                self._type = 'interface'
+            if property is not None:
+                self._property = property
+                self._type = 'property'
+
+        elif type_of_union == 'string_example':
             if string_example is None:
                 raise ValueError('a union value must not be None')
             self._string_example = string_example
             self._type = 'stringExample'
-        if type_of_union == 'set':
+        elif type_of_union == 'set':
             if set is None:
                 raise ValueError('a union value must not be None')
             self._set = set
             self._type = 'set'
-        if type_of_union == 'this_field_is_an_integer':
+        elif type_of_union == 'this_field_is_an_integer':
             if this_field_is_an_integer is None:
                 raise ValueError('a union value must not be None')
             self._this_field_is_an_integer = this_field_is_an_integer
             self._type = 'thisFieldIsAnInteger'
-        if type_of_union == 'also_an_integer':
+        elif type_of_union == 'also_an_integer':
             if also_an_integer is None:
                 raise ValueError('a union value must not be None')
             self._also_an_integer = also_an_integer
             self._type = 'alsoAnInteger'
-        if type_of_union == 'if_':
+        elif type_of_union == 'if_':
             if if_ is None:
                 raise ValueError('a union value must not be None')
             self._if_ = if_
             self._type = 'if'
-        if type_of_union == 'new':
+        elif type_of_union == 'new':
             if new is None:
                 raise ValueError('a union value must not be None')
             self._new = new
             self._type = 'new'
-        if type_of_union == 'interface':
+        elif type_of_union == 'interface':
             if interface is None:
                 raise ValueError('a union value must not be None')
             self._interface = interface
             self._type = 'interface'
-        if type_of_union == 'property':
+        elif type_of_union == 'property':
             if property is None:
                 raise ValueError('a union value must not be None')
             self._property = property
@@ -1755,12 +1792,23 @@ class with_imports_UnionWithImports(ConjureUnionType):
             imported: Optional["product_AnyMapExample"] = None,
             type_of_union: Optional[str] = None
             ) -> None:
-        if type_of_union == 'string':
+        if type_of_union is None:
+            if (string is not None) + (imported is not None) != 1:
+                raise ValueError('a union must contain a single member')
+
+            if string is not None:
+                self._string = string
+                self._type = 'string'
+            if imported is not None:
+                self._imported = imported
+                self._type = 'imported'
+
+        elif type_of_union == 'string':
             if string is None:
                 raise ValueError('a union value must not be None')
             self._string = string
             self._type = 'string'
-        if type_of_union == 'imported':
+        elif type_of_union == 'imported':
             if imported is None:
                 raise ValueError('a union value must not be None')
             self._imported = imported

--- a/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
@@ -1121,12 +1121,12 @@ class product_OptionsUnion(ConjureUnionType):
 
     def __init__(
             self,
-            options: Optional[str] = None
+            options: Optional[str] = None,
+            type_of_union: str = ""
             ) -> None:
-        if (options is not None) != 1:
-            raise ValueError('a union must contain a single member')
-
-        if options is not None:
+        if type_of_union == 'options':
+            if options is None:
+                raise ValueError('a union value must not be None')
             self._options_ = options
             self._type = 'options'
 
@@ -1412,33 +1412,47 @@ class product_UnionTypeExample(ConjureUnionType):
             if_: Optional[int] = None,
             new: Optional[int] = None,
             interface: Optional[int] = None,
-            property: Optional[int] = None
+            property: Optional[int] = None,
+            type_of_union: str = ""
             ) -> None:
-        if (string_example is not None) + (set is not None) + (this_field_is_an_integer is not None) + (also_an_integer is not None) + (if_ is not None) + (new is not None) + (interface is not None) + (property is not None) != 1:
-            raise ValueError('a union must contain a single member')
-
-        if string_example is not None:
+        if type_of_union == 'string_example':
+            if string_example is None:
+                raise ValueError('a union value must not be None')
             self._string_example = string_example
             self._type = 'stringExample'
-        if set is not None:
+        if type_of_union == 'set':
+            if set is None:
+                raise ValueError('a union value must not be None')
             self._set = set
             self._type = 'set'
-        if this_field_is_an_integer is not None:
+        if type_of_union == 'this_field_is_an_integer':
+            if this_field_is_an_integer is None:
+                raise ValueError('a union value must not be None')
             self._this_field_is_an_integer = this_field_is_an_integer
             self._type = 'thisFieldIsAnInteger'
-        if also_an_integer is not None:
+        if type_of_union == 'also_an_integer':
+            if also_an_integer is None:
+                raise ValueError('a union value must not be None')
             self._also_an_integer = also_an_integer
             self._type = 'alsoAnInteger'
-        if if_ is not None:
+        if type_of_union == 'if_':
+            if if_ is None:
+                raise ValueError('a union value must not be None')
             self._if_ = if_
             self._type = 'if'
-        if new is not None:
+        if type_of_union == 'new':
+            if new is None:
+                raise ValueError('a union value must not be None')
             self._new = new
             self._type = 'new'
-        if interface is not None:
+        if type_of_union == 'interface':
+            if interface is None:
+                raise ValueError('a union value must not be None')
             self._interface = interface
             self._type = 'interface'
-        if property is not None:
+        if type_of_union == 'property':
+            if property is None:
+                raise ValueError('a union value must not be None')
             self._property = property
             self._type = 'property'
 
@@ -1738,15 +1752,17 @@ class with_imports_UnionWithImports(ConjureUnionType):
     def __init__(
             self,
             string: Optional[str] = None,
-            imported: Optional["product_AnyMapExample"] = None
+            imported: Optional["product_AnyMapExample"] = None,
+            type_of_union: str = ""
             ) -> None:
-        if (string is not None) + (imported is not None) != 1:
-            raise ValueError('a union must contain a single member')
-
-        if string is not None:
+        if type_of_union == 'string':
+            if string is None:
+                raise ValueError('a union value must not be None')
             self._string = string
             self._type = 'string'
-        if imported is not None:
+        if type_of_union == 'imported':
+            if imported is None:
+                raise ValueError('a union value must not be None')
             self._imported = imported
             self._type = 'imported'
 

--- a/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
@@ -1137,7 +1137,7 @@ class product_OptionsUnion(ConjureUnionType):
     def accept(self, visitor) -> Any:
         if not isinstance(visitor, product_OptionsUnionVisitor):
             raise ValueError('{} is not an instance of product_OptionsUnionVisitor'.format(visitor.__class__.__name__))
-        if self._type == 'options':
+        if self._type == 'options' and self.options is not None:
             return visitor._options(self.options)
 
 
@@ -1494,21 +1494,21 @@ class product_UnionTypeExample(ConjureUnionType):
     def accept(self, visitor) -> Any:
         if not isinstance(visitor, product_UnionTypeExampleVisitor):
             raise ValueError('{} is not an instance of product_UnionTypeExampleVisitor'.format(visitor.__class__.__name__))
-        if self._type == 'string_example':
+        if self._type == 'string_example' and self.string_example is not None:
             return visitor._string_example(self.string_example)
-        if self._type == 'set':
+        if self._type == 'set' and self.set is not None:
             return visitor._set(self.set)
-        if self._type == 'this_field_is_an_integer':
+        if self._type == 'this_field_is_an_integer' and self.this_field_is_an_integer is not None:
             return visitor._this_field_is_an_integer(self.this_field_is_an_integer)
-        if self._type == 'also_an_integer':
+        if self._type == 'also_an_integer' and self.also_an_integer is not None:
             return visitor._also_an_integer(self.also_an_integer)
-        if self._type == 'if_':
+        if self._type == 'if_' and self.if_ is not None:
             return visitor._if(self.if_)
-        if self._type == 'new':
+        if self._type == 'new' and self.new is not None:
             return visitor._new(self.new)
-        if self._type == 'interface':
+        if self._type == 'interface' and self.interface is not None:
             return visitor._interface(self.interface)
-        if self._type == 'property':
+        if self._type == 'property' and self.property is not None:
             return visitor._property(self.property)
 
 
@@ -1777,9 +1777,9 @@ class with_imports_UnionWithImports(ConjureUnionType):
     def accept(self, visitor) -> Any:
         if not isinstance(visitor, with_imports_UnionWithImportsVisitor):
             raise ValueError('{} is not an instance of with_imports_UnionWithImportsVisitor'.format(visitor.__class__.__name__))
-        if self._type == 'string':
+        if self._type == 'string' and self.string is not None:
             return visitor._string(self.string)
-        if self._type == 'imported':
+        if self._type == 'imported' and self.imported is not None:
             return visitor._imported(self.imported)
 
 

--- a/conjure-python-verifier/python/test/client/test_code_gen.py
+++ b/conjure-python-verifier/python/test/client/test_code_gen.py
@@ -48,4 +48,6 @@ def test_union_visitor():
         def _options(self, value):
             return value
 
+    # test for backwards compatibility
+    assert OptionsUnion(options="options").accept(TestOptionsUnionVisitor()) == "options"
     assert OptionsUnion(options="options", type_of_union="options").accept(TestOptionsUnionVisitor()) == "options"

--- a/conjure-python-verifier/python/test/client/test_code_gen.py
+++ b/conjure-python-verifier/python/test/client/test_code_gen.py
@@ -48,4 +48,4 @@ def test_union_visitor():
         def _options(self, value):
             return value
 
-    assert OptionsUnion(options="options").accept(TestOptionsUnionVisitor()) == "options"
+    assert OptionsUnion(options="options", type_of_union="options").accept(TestOptionsUnionVisitor()) == "options"


### PR DESCRIPTION
Context on why this PR is necessary: https://support-jira.palantir.tech/browse/PDS-340288

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add type_of_union to the constructor of UnionType
Use type_of_union to determine the union variant instead of checking if the value is None
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
Should be merged with https://github.com/palantir/conjure-python-client/pull/141
