### PR TITLE
Add option to return none on unknown union variants

### DIFF
--- a/changelog/@unreleased/pr-714.v2.yml
+++ b/changelog/@unreleased/pr-714.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add option to return none on unknown union variants
+  links:
+  - https://github.com/palantir/conjure-python/pull/714

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java
@@ -233,11 +233,12 @@ public interface PythonEndpointDefinition extends Emittable {
                 poetWriter.writeIndentedLine("_decoder = ConjureDecoder()");
                 if (isOptionalReturnType()) {
                     poetWriter.writeIndentedLine(
-                            "return None if _response.status_code == 204 else _decoder.decode(_response.json(), %s)",
+                            "return None if _response.status_code == 204 else _decoder.decode(_response.json()"
+                                    + ", %s, self._return_none_for_unknown_union_types)",
                             pythonReturnType().get());
                 } else {
                     poetWriter.writeIndentedLine(
-                            "return _decoder.decode(_response.json(), %s)",
+                            "return _decoder.decode(_response.json(), %s, self._return_none_for_unknown_union_types)",
                             pythonReturnType().get());
                 }
             } else {

--- a/conjure-python-core/src/test/java/com/palantir/conjure/python/ConjurePythonGeneratorTest.java
+++ b/conjure-python-core/src/test/java/com/palantir/conjure/python/ConjurePythonGeneratorTest.java
@@ -39,7 +39,7 @@ public final class ConjurePythonGeneratorTest {
             .packageName("package-name")
             .packageVersion("0.0.0")
             .packageDescription("project description")
-            .minConjureClientVersion("2.1.0")
+            .minConjureClientVersion("2.8.0")
             .generatorVersion("0.0.0")
             .shouldWriteCondaRecipe(true)
             .generateRawSource(false)

--- a/conjure-python-core/src/test/resources/services/expected/conda_recipe/meta.yaml
+++ b/conjure-python-core/src/test/resources/services/expected/conda_recipe/meta.yaml
@@ -15,9 +15,9 @@ requirements:
         - python
         - setuptools
         - requests
-        - conjure-python-client >=2.1.0,<3
+        - conjure-python-client >=2.8.0,<3
 
     run:
         - python
         - requests
-        - conjure-python-client >=2.1.0,<3
+        - conjure-python-client >=2.8.0,<3

--- a/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
@@ -54,7 +54,7 @@ class another_TestService(Service):
             json=_json)
 
         _decoder = ConjureDecoder()
-        return _decoder.decode(_response.json(), Dict[str, product_datasets_BackingFileSystem])
+        return _decoder.decode(_response.json(), Dict[str, product_datasets_BackingFileSystem], self._return_none_for_unknown_union_types)
 
     def create_dataset(self, auth_header: str, request: "product_CreateDatasetRequest", test_header_arg: str) -> "product_datasets_Dataset":
 
@@ -84,7 +84,7 @@ class another_TestService(Service):
             json=_json)
 
         _decoder = ConjureDecoder()
-        return _decoder.decode(_response.json(), product_datasets_Dataset)
+        return _decoder.decode(_response.json(), product_datasets_Dataset, self._return_none_for_unknown_union_types)
 
     def get_dataset(self, auth_header: str, dataset_rid: str) -> Optional["product_datasets_Dataset"]:
 
@@ -113,7 +113,7 @@ class another_TestService(Service):
             json=_json)
 
         _decoder = ConjureDecoder()
-        return None if _response.status_code == 204 else _decoder.decode(_response.json(), OptionalTypeWrapper[product_datasets_Dataset])
+        return None if _response.status_code == 204 else _decoder.decode(_response.json(), OptionalTypeWrapper[product_datasets_Dataset], self._return_none_for_unknown_union_types)
 
     def get_raw_data(self, auth_header: str, dataset_rid: str) -> Any:
 
@@ -173,7 +173,7 @@ class another_TestService(Service):
             json=_json)
 
         _decoder = ConjureDecoder()
-        return None if _response.status_code == 204 else _decoder.decode(_response.json(), OptionalTypeWrapper[BinaryType])
+        return None if _response.status_code == 204 else _decoder.decode(_response.json(), OptionalTypeWrapper[BinaryType], self._return_none_for_unknown_union_types)
 
     def upload_raw_data(self, auth_header: str, input: Any) -> None:
 
@@ -232,7 +232,7 @@ class another_TestService(Service):
             json=_json)
 
         _decoder = ConjureDecoder()
-        return _decoder.decode(_response.json(), List[str])
+        return _decoder.decode(_response.json(), List[str], self._return_none_for_unknown_union_types)
 
     def get_branches_deprecated(self, auth_header: str, dataset_rid: str) -> List[str]:
         """
@@ -264,7 +264,7 @@ class another_TestService(Service):
             json=_json)
 
         _decoder = ConjureDecoder()
-        return _decoder.decode(_response.json(), List[str])
+        return _decoder.decode(_response.json(), List[str], self._return_none_for_unknown_union_types)
 
     def resolve_branch(self, auth_header: str, branch: str, dataset_rid: str) -> Optional[str]:
 
@@ -294,7 +294,7 @@ class another_TestService(Service):
             json=_json)
 
         _decoder = ConjureDecoder()
-        return None if _response.status_code == 204 else _decoder.decode(_response.json(), OptionalTypeWrapper[str])
+        return None if _response.status_code == 204 else _decoder.decode(_response.json(), OptionalTypeWrapper[str], self._return_none_for_unknown_union_types)
 
     def test_param(self, auth_header: str, dataset_rid: str) -> Optional[str]:
 
@@ -323,7 +323,7 @@ class another_TestService(Service):
             json=_json)
 
         _decoder = ConjureDecoder()
-        return None if _response.status_code == 204 else _decoder.decode(_response.json(), OptionalTypeWrapper[str])
+        return None if _response.status_code == 204 else _decoder.decode(_response.json(), OptionalTypeWrapper[str], self._return_none_for_unknown_union_types)
 
     def test_query_params(self, auth_header: str, implicit: str, something: str, list: List[int] = None, set: List[int] = None) -> int:
         list = list if list is not None else []
@@ -357,7 +357,7 @@ class another_TestService(Service):
             json=_json)
 
         _decoder = ConjureDecoder()
-        return _decoder.decode(_response.json(), int)
+        return _decoder.decode(_response.json(), int, self._return_none_for_unknown_union_types)
 
     def test_boolean(self, auth_header: str) -> bool:
 
@@ -385,7 +385,7 @@ class another_TestService(Service):
             json=_json)
 
         _decoder = ConjureDecoder()
-        return _decoder.decode(_response.json(), bool)
+        return _decoder.decode(_response.json(), bool, self._return_none_for_unknown_union_types)
 
     def test_double(self, auth_header: str) -> float:
 
@@ -413,7 +413,7 @@ class another_TestService(Service):
             json=_json)
 
         _decoder = ConjureDecoder()
-        return _decoder.decode(_response.json(), float)
+        return _decoder.decode(_response.json(), float, self._return_none_for_unknown_union_types)
 
     def test_integer(self, auth_header: str) -> int:
 
@@ -441,7 +441,7 @@ class another_TestService(Service):
             json=_json)
 
         _decoder = ConjureDecoder()
-        return _decoder.decode(_response.json(), int)
+        return _decoder.decode(_response.json(), int, self._return_none_for_unknown_union_types)
 
 
 another_TestService.__name__ = "TestService"

--- a/conjure-python-core/src/test/resources/services/expected/setup.py
+++ b/conjure-python-core/src/test/resources/services/expected/setup.py
@@ -13,6 +13,6 @@ setup(
     packages=find_packages(),
     install_requires=[
         'requests',
-        'conjure-python-client>=2.1.0,<3',
+        'conjure-python-client>=2.8.0,<3',
     ],
 )

--- a/conjure-python-core/src/test/resources/types/expected/conda_recipe/meta.yaml
+++ b/conjure-python-core/src/test/resources/types/expected/conda_recipe/meta.yaml
@@ -15,9 +15,9 @@ requirements:
         - python
         - setuptools
         - requests
-        - conjure-python-client >=2.1.0,<3
+        - conjure-python-client >=2.8.0,<3
 
     run:
         - python
         - requests
-        - conjure-python-client >=2.1.0,<3
+        - conjure-python-client >=2.8.0,<3

--- a/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
@@ -59,7 +59,7 @@ class another_TestService(Service):
             json=_json)
 
         _decoder = ConjureDecoder()
-        return _decoder.decode(_response.json(), Dict[str, product_datasets_BackingFileSystem])
+        return _decoder.decode(_response.json(), Dict[str, product_datasets_BackingFileSystem], self._return_none_for_unknown_union_types)
 
     def create_dataset(self, auth_header: str, request: "product_CreateDatasetRequest", test_header_arg: str) -> "product_datasets_Dataset":
 
@@ -89,7 +89,7 @@ class another_TestService(Service):
             json=_json)
 
         _decoder = ConjureDecoder()
-        return _decoder.decode(_response.json(), product_datasets_Dataset)
+        return _decoder.decode(_response.json(), product_datasets_Dataset, self._return_none_for_unknown_union_types)
 
     def get_dataset(self, auth_header: str, dataset_rid: str) -> Optional["product_datasets_Dataset"]:
 
@@ -118,7 +118,7 @@ class another_TestService(Service):
             json=_json)
 
         _decoder = ConjureDecoder()
-        return None if _response.status_code == 204 else _decoder.decode(_response.json(), OptionalTypeWrapper[product_datasets_Dataset])
+        return None if _response.status_code == 204 else _decoder.decode(_response.json(), OptionalTypeWrapper[product_datasets_Dataset], self._return_none_for_unknown_union_types)
 
     def get_raw_data(self, auth_header: str, dataset_rid: str) -> Any:
 
@@ -178,7 +178,7 @@ class another_TestService(Service):
             json=_json)
 
         _decoder = ConjureDecoder()
-        return None if _response.status_code == 204 else _decoder.decode(_response.json(), OptionalTypeWrapper[BinaryType])
+        return None if _response.status_code == 204 else _decoder.decode(_response.json(), OptionalTypeWrapper[BinaryType], self._return_none_for_unknown_union_types)
 
     def upload_raw_data(self, auth_header: str, input: Any) -> None:
 
@@ -237,7 +237,7 @@ class another_TestService(Service):
             json=_json)
 
         _decoder = ConjureDecoder()
-        return _decoder.decode(_response.json(), List[str])
+        return _decoder.decode(_response.json(), List[str], self._return_none_for_unknown_union_types)
 
     def get_branches_deprecated(self, auth_header: str, dataset_rid: str) -> List[str]:
         """
@@ -269,7 +269,7 @@ class another_TestService(Service):
             json=_json)
 
         _decoder = ConjureDecoder()
-        return _decoder.decode(_response.json(), List[str])
+        return _decoder.decode(_response.json(), List[str], self._return_none_for_unknown_union_types)
 
     def resolve_branch(self, auth_header: str, branch: str, dataset_rid: str) -> Optional[str]:
 
@@ -299,7 +299,7 @@ class another_TestService(Service):
             json=_json)
 
         _decoder = ConjureDecoder()
-        return None if _response.status_code == 204 else _decoder.decode(_response.json(), OptionalTypeWrapper[str])
+        return None if _response.status_code == 204 else _decoder.decode(_response.json(), OptionalTypeWrapper[str], self._return_none_for_unknown_union_types)
 
     def test_param(self, auth_header: str, dataset_rid: str) -> Optional[str]:
 
@@ -328,7 +328,7 @@ class another_TestService(Service):
             json=_json)
 
         _decoder = ConjureDecoder()
-        return None if _response.status_code == 204 else _decoder.decode(_response.json(), OptionalTypeWrapper[str])
+        return None if _response.status_code == 204 else _decoder.decode(_response.json(), OptionalTypeWrapper[str], self._return_none_for_unknown_union_types)
 
     def test_query_params(self, auth_header: str, implicit: str, something: str, list: List[int] = None, set: List[int] = None) -> int:
         list = list if list is not None else []
@@ -362,7 +362,7 @@ class another_TestService(Service):
             json=_json)
 
         _decoder = ConjureDecoder()
-        return _decoder.decode(_response.json(), int)
+        return _decoder.decode(_response.json(), int, self._return_none_for_unknown_union_types)
 
     def test_boolean(self, auth_header: str) -> bool:
 
@@ -390,7 +390,7 @@ class another_TestService(Service):
             json=_json)
 
         _decoder = ConjureDecoder()
-        return _decoder.decode(_response.json(), bool)
+        return _decoder.decode(_response.json(), bool, self._return_none_for_unknown_union_types)
 
     def test_double(self, auth_header: str) -> float:
 
@@ -418,7 +418,7 @@ class another_TestService(Service):
             json=_json)
 
         _decoder = ConjureDecoder()
-        return _decoder.decode(_response.json(), float)
+        return _decoder.decode(_response.json(), float, self._return_none_for_unknown_union_types)
 
     def test_integer(self, auth_header: str) -> int:
 
@@ -446,7 +446,7 @@ class another_TestService(Service):
             json=_json)
 
         _decoder = ConjureDecoder()
-        return _decoder.decode(_response.json(), int)
+        return _decoder.decode(_response.json(), int, self._return_none_for_unknown_union_types)
 
 
 another_TestService.__name__ = "TestService"
@@ -482,7 +482,7 @@ class nested_deeply_nested_service_DeeplyNestedService(Service):
             json=_json)
 
         _decoder = ConjureDecoder()
-        return _decoder.decode(_response.json(), str)
+        return _decoder.decode(_response.json(), str, self._return_none_for_unknown_union_types)
 
 
 nested_deeply_nested_service_DeeplyNestedService.__name__ = "DeeplyNestedService"
@@ -518,7 +518,7 @@ class nested_service2_SimpleNestedService2(Service):
             json=_json)
 
         _decoder = ConjureDecoder()
-        return _decoder.decode(_response.json(), str)
+        return _decoder.decode(_response.json(), str, self._return_none_for_unknown_union_types)
 
 
 nested_service2_SimpleNestedService2.__name__ = "SimpleNestedService2"
@@ -554,7 +554,7 @@ class nested_service_SimpleNestedService(Service):
             json=_json)
 
         _decoder = ConjureDecoder()
-        return _decoder.decode(_response.json(), str)
+        return _decoder.decode(_response.json(), str, self._return_none_for_unknown_union_types)
 
 
 nested_service_SimpleNestedService.__name__ = "SimpleNestedService"
@@ -1744,7 +1744,7 @@ class with_imports_ImportService(Service):
             json=_json)
 
         _decoder = ConjureDecoder()
-        return _decoder.decode(_response.json(), product_datasets_BackingFileSystem)
+        return _decoder.decode(_response.json(), product_datasets_BackingFileSystem, self._return_none_for_unknown_union_types)
 
 
 with_imports_ImportService.__name__ = "ImportService"

--- a/conjure-python-core/src/test/resources/types/expected/setup.py
+++ b/conjure-python-core/src/test/resources/types/expected/setup.py
@@ -13,6 +13,6 @@ setup(
     packages=find_packages(),
     install_requires=[
         'requests',
-        'conjure-python-client>=2.1.0,<3',
+        'conjure-python-client>=2.8.0,<3',
     ],
 )

--- a/conjure-python-verifier/python/Pipfile
+++ b/conjure-python-verifier/python/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-conjure-python-client = "==2.1.0"
+conjure-python-client = "==2.8.0"
 
 [dev-packages]
 black = "*"

--- a/conjure-python-verifier/python/tox.ini
+++ b/conjure-python-verifier/python/tox.ini
@@ -14,7 +14,7 @@ deps =
     pytest-pylint==0.18.0
     pytest-html==3.1.1
 setenv =
-    CONJURE_PYTHON_CLIENT_VERSION = 2.1.0
+    CONJURE_PYTHON_CLIENT_VERSION = 2.8.0
     PYTHONDONTWRITEBYTECODE = 1
     ROOT_PROJECT_DIR = {toxinidir}
 

--- a/conjure-python/src/test/java/com/palantir/conjure/python/cli/ConjurePythonCliTest.java
+++ b/conjure-python/src/test/java/com/palantir/conjure/python/cli/ConjurePythonCliTest.java
@@ -161,6 +161,6 @@ public class ConjurePythonCliTest {
 
     @Test
     public void loadBuildConfiguration() {
-        assertThat(BuildConfiguration.load().minConjureClientVersion()).isEqualTo("2.1.0");
+        assertThat(BuildConfiguration.load().minConjureClientVersion()).isEqualTo("2.8.0");
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 org.gradle.parallel=true
-conjurePythonClientVersion=2.1.0
+conjurePythonClientVersion=2.8.0
 org.gradle.jvmargs = --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED


### PR DESCRIPTION
## Before this PR
See https://github.com/palantir/conjure-python-client/issues/129

https://github.com/palantir/conjure-python-client/pull/150 added the option in conjure-python-client to return `None` when encountering unknown union variants, but conjure-python doesn't include this option in the conjure generated code.

## After this PR
This PR:
- Upgrades the conjure-python-client dependency to 2.8.0
- Updates the code generating a `Service` to propagate the `_return_none_for_unknown_union_types` flag to the `decode` method. This flag can be passed by the caller to [RequestsClient.create(..)](https://github.com/palantir/conjure-python-client/blob/2.8.0/conjure_python_client/_http/requests_client.py#L166)

==COMMIT_MSG==
Add option to return none on unknown union variants
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

