### PR TITLE
fix: reorder union properties with builtin names

### DIFF
--- a/changelog/@unreleased/pr-748.v2.yml
+++ b/changelog/@unreleased/pr-748.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: reorder union properties with builtin names
+  links:
+  - https://github.com/palantir/conjure-python/pull/748

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
@@ -178,22 +178,14 @@ public interface UnionSnippet extends PythonSnippet {
             poetWriter.decreaseIndent();
 
             // python @builtins.property for each member of the union
-            options().forEach(option -> {
-                poetWriter.writeLine();
+            options().stream()
+                    .filter(option -> !propertyName(option).equals("float"))
+                    .forEach(option -> emitProperty(poetWriter, option));
 
-                poetWriter.writeIndentedLine("@builtins.property");
-                poetWriter.writeIndentedLine(
-                        String.format("def %s(self) -> Optional[%s]:", propertyName(option), option.myPyType()));
-
-                poetWriter.increaseIndent();
-                option.docs().ifPresent(docs -> {
-                    poetWriter.writeIndentedLine("\"\"\"");
-                    poetWriter.writeIndentedLine(docs.get().trim());
-                    poetWriter.writeIndentedLine("\"\"\"");
-                });
-                poetWriter.writeIndentedLine(String.format("return self.%s", fieldName(option)));
-                poetWriter.decreaseIndent();
-            });
+            // properties with builtin names must come after other properties
+            options().stream()
+                    .filter(option -> propertyName(option).equals("float"))
+                    .forEach(option -> emitProperty(poetWriter, option));
 
             String visitorName = String.format("%sVisitor", className());
             String definitionVisitorName = String.format("%sVisitor", definitionName());
@@ -244,6 +236,23 @@ public interface UnionSnippet extends PythonSnippet {
 
             PythonClassRenamer.renameClass(poetWriter, visitorName, definitionPackage(), definitionVisitorName);
         });
+    }
+
+    private static void emitProperty(PythonPoetWriter poetWriter, PythonField option) {
+        poetWriter.writeLine();
+
+        poetWriter.writeIndentedLine("@builtins.property");
+        poetWriter.writeIndentedLine(
+                String.format("def %s(self) -> Optional[%s]:", propertyName(option), option.myPyType()));
+
+        poetWriter.increaseIndent();
+        option.docs().ifPresent(docs -> {
+            poetWriter.writeIndentedLine("\"\"\"");
+            poetWriter.writeIndentedLine(docs.get().trim());
+            poetWriter.writeIndentedLine("\"\"\"");
+        });
+        poetWriter.writeIndentedLine(String.format("return self.%s", fieldName(option)));
+        poetWriter.decreaseIndent();
     }
 
     class Builder extends ImmutableUnionSnippet.Builder {}


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
reorder union properties with builtin names
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

