### PR TITLE
fix: order union properties to avoid type collision

### DIFF
--- a/changelog/@unreleased/pr-749.v2.yml
+++ b/changelog/@unreleased/pr-749.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: order union properties to avoid type collision
+  links:
+  - https://github.com/palantir/conjure-python/pull/749

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
@@ -183,6 +183,8 @@ public interface UnionSnippet extends PythonSnippet {
                     .forEach(option -> emitProperty(poetWriter, option));
 
             // properties with builtin names must come after other properties
+            // can be removed once these names are properly sanitized but
+            // that will require a breaking change and major version bump
             options().stream()
                     .filter(option -> propertyName(option).equals("float"))
                     .forEach(option -> emitProperty(poetWriter, option));

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
@@ -178,22 +178,14 @@ public interface UnionSnippet extends PythonSnippet {
             poetWriter.decreaseIndent();
 
             // python @builtins.property for each member of the union
-            options().forEach(option -> {
-                poetWriter.writeLine();
+            options().stream()
+                    .filter(option -> !propertyName(option).equals("float"))
+                    .forEach(option -> emitProperty(poetWriter, option));
 
-                poetWriter.writeIndentedLine("@builtins.property");
-                poetWriter.writeIndentedLine(
-                        String.format("def %s(self) -> Optional[%s]:", propertyName(option), option.myPyType()));
-
-                poetWriter.increaseIndent();
-                option.docs().ifPresent(docs -> {
-                    poetWriter.writeIndentedLine("\"\"\"");
-                    poetWriter.writeIndentedLine(docs.get().trim());
-                    poetWriter.writeIndentedLine("\"\"\"");
-                });
-                poetWriter.writeIndentedLine(String.format("return self.%s", fieldName(option)));
-                poetWriter.decreaseIndent();
-            });
+            // properties with builtin names must come after other properties
+            options().stream()
+                    .filter(option -> propertyName(option).equals("float"))
+                    .forEach(option -> emitProperty(poetWriter, option));
 
             String visitorName = String.format("%sVisitor", className());
             String definitionVisitorName = String.format("%sVisitor", definitionName());
@@ -244,6 +236,23 @@ public interface UnionSnippet extends PythonSnippet {
 
             PythonClassRenamer.renameClass(poetWriter, visitorName, definitionPackage(), definitionVisitorName);
         });
+    }
+
+    private static void emitProperty(PythonPoetWriter poetWriter, PythonField option) {
+        poetWriter.writeLine();
+
+        poetWriter.writeIndentedLine("@builtins.property");
+        poetWriter.writeIndentedLine(
+                String.format("def %s(self) -> Optional[%s]:", propertyName(option), option.myPyType()));
+
+        poetWriter.increaseIndent();
+        option.docs().ifPresent(docs -> {
+            poetWriter.writeIndentedLine("\"\"\"");
+            poetWriter.writeIndentedLine(docs.get().trim());
+            poetWriter.writeIndentedLine("\"\"\"");
+        });
+        poetWriter.writeIndentedLine(String.format("return self.%s", fieldName(option)));
+        poetWriter.decreaseIndent();
     }
 
     class Builder extends ImmutableUnionSnippet.Builder {}

--- a/conjure-python-core/src/test/resources/types/example-types.yml
+++ b/conjure-python-core/src/test/resources/types/example-types.yml
@@ -172,3 +172,9 @@ types:
         alias: RecursiveObjectAlias
       CollectionAliasExample:
         alias: map<StringAliasExample, RecursiveObjectAlias>
+      UnionWithBuiltinVariantName:
+        union:
+          # the name of this variant is 'float' which conflicts with the python type 'float'
+          float: double
+          # the python type for this field is 'float' which conflicts with the variant name above
+          double: double

--- a/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
@@ -1594,6 +1594,83 @@ product_UnionTypeExampleVisitor.__qualname__ = "UnionTypeExampleVisitor"
 product_UnionTypeExampleVisitor.__module__ = "package_name.product"
 
 
+class product_UnionWithBuiltinVariantName(ConjureUnionType):
+    _float: Optional[float] = None
+    _double: Optional[float] = None
+
+    @builtins.classmethod
+    def _options(cls) -> Dict[str, ConjureFieldDefinition]:
+        return {
+            'float': ConjureFieldDefinition('float', float),
+            'double': ConjureFieldDefinition('double', float)
+        }
+
+    def __init__(
+            self,
+            float: Optional[float] = None,
+            double: Optional[float] = None,
+            type_of_union: Optional[str] = None
+            ) -> None:
+        if type_of_union is None:
+            if (float is not None) + (double is not None) != 1:
+                raise ValueError('a union must contain a single member')
+
+            if float is not None:
+                self._float = float
+                self._type = 'float'
+            if double is not None:
+                self._double = double
+                self._type = 'double'
+
+        elif type_of_union == 'float':
+            if float is None:
+                raise ValueError('a union value must not be None')
+            self._float = float
+            self._type = 'float'
+        elif type_of_union == 'double':
+            if double is None:
+                raise ValueError('a union value must not be None')
+            self._double = double
+            self._type = 'double'
+
+    @builtins.property
+    def float(self) -> Optional[float]:
+        return self._float
+
+    @builtins.property
+    def double(self) -> Optional[float]:
+        return self._double
+
+    def accept(self, visitor) -> Any:
+        if not isinstance(visitor, product_UnionWithBuiltinVariantNameVisitor):
+            raise ValueError('{} is not an instance of product_UnionWithBuiltinVariantNameVisitor'.format(visitor.__class__.__name__))
+        if self._type == 'float' and self.float is not None:
+            return visitor._float(self.float)
+        if self._type == 'double' and self.double is not None:
+            return visitor._double(self.double)
+
+
+product_UnionWithBuiltinVariantName.__name__ = "UnionWithBuiltinVariantName"
+product_UnionWithBuiltinVariantName.__qualname__ = "UnionWithBuiltinVariantName"
+product_UnionWithBuiltinVariantName.__module__ = "package_name.product"
+
+
+class product_UnionWithBuiltinVariantNameVisitor:
+
+    @abstractmethod
+    def _float(self, float: float) -> Any:
+        pass
+
+    @abstractmethod
+    def _double(self, double: float) -> Any:
+        pass
+
+
+product_UnionWithBuiltinVariantNameVisitor.__name__ = "UnionWithBuiltinVariantNameVisitor"
+product_UnionWithBuiltinVariantNameVisitor.__qualname__ = "UnionWithBuiltinVariantNameVisitor"
+product_UnionWithBuiltinVariantNameVisitor.__module__ = "package_name.product"
+
+
 class product_UuidExample(ConjureBeanType):
 
     @builtins.classmethod

--- a/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
@@ -1634,12 +1634,12 @@ class product_UnionWithBuiltinVariantName(ConjureUnionType):
             self._type = 'double'
 
     @builtins.property
-    def float(self) -> Optional[float]:
-        return self._float
-
-    @builtins.property
     def double(self) -> Optional[float]:
         return self._double
+
+    @builtins.property
+    def float(self) -> Optional[float]:
+        return self._float
 
     def accept(self, visitor) -> Any:
         if not isinstance(visitor, product_UnionWithBuiltinVariantNameVisitor):

--- a/conjure-python-core/src/test/resources/types/expected/package_name/product/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/product/__init__.py
@@ -43,6 +43,8 @@ from .._impl import (
     product_StringExample as StringExample,
     product_UnionTypeExample as UnionTypeExample,
     product_UnionTypeExampleVisitor as UnionTypeExampleVisitor,
+    product_UnionWithBuiltinVariantName as UnionWithBuiltinVariantName,
+    product_UnionWithBuiltinVariantNameVisitor as UnionWithBuiltinVariantNameVisitor,
     product_UuidAliasExample as UuidAliasExample,
     product_UuidExample as UuidExample,
 )

--- a/conjure-python-verifier/python/test/client/test_import_all.py
+++ b/conjure-python-verifier/python/test/client/test_import_all.py
@@ -1,4 +1,6 @@
 from generated_integration import *
+from generated_integration.product import *
+from totally_fake_made_up import *
 
 def test():
     pass  # we just need to confirm that the above import didn't fail

--- a/conjure-python-verifier/python/test/client/test_import_all.py
+++ b/conjure-python-verifier/python/test/client/test_import_all.py
@@ -1,6 +1,4 @@
 from generated_integration import *
-from generated_integration.product import *
-from totally_fake_made_up import *
 
 def test():
     pass  # we just need to confirm that the above import didn't fail


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
order union properties to avoid type collision
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

