### PR TITLE
Fix: Pin pylint to the last functioning release to unblock contributions

### DIFF
--- a/changelog/@unreleased/pr-778.v2.yml
+++ b/changelog/@unreleased/pr-778.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Pin pylint to the last functioning release to unblock contributions
+  links:
+  - https://github.com/palantir/conjure-python/pull/778

--- a/conjure-python-verifier/python/tox.ini
+++ b/conjure-python-verifier/python/tox.ini
@@ -11,6 +11,7 @@ commands =
     pytest -v --capture=no --junitxml=./build/pytest-{envname}.xml --html=./build/pytest-{envname}.html --self-contained-html {posargs:test/}
 deps =
     pytest==7.0.1
+    pylint==2.17.7
     pytest-pylint==0.18.0
     pytest-html==3.1.1
 setenv =


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
All new runs of CI would pick up pylint major version 3, which is incompatible with the release of pytest-pylint we're relying on causing:
```
Traceback (most recent call last):
  File "/home/circleci/project/conjure-python-verifier/python/.tox/py3/bin/pytest", line 8, in <module>
    sys.exit(console_main())
  File "/home/circleci/project/conjure-python-verifier/python/.tox/py3/lib/python3.8/site-packages/_pytest/config/__init__.py", line 188, in console_main
    code = main()
  File "/home/circleci/project/conjure-python-verifier/python/.tox/py3/lib/python3.8/site-packages/_pytest/config/__init__.py", line 146, in main
    config = _prepareconfig(args, plugins)
  File "/home/circleci/project/conjure-python-verifier/python/.tox/py3/lib/python3.8/site-packages/_pytest/config/__init__.py", line 325, in _prepareconfig
    config = pluginmanager.hook.pytest_cmdline_parse(
  File "/home/circleci/project/conjure-python-verifier/python/.tox/py3/lib/python3.8/site-packages/pluggy/_hooks.py", line 501, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/home/circleci/project/conjure-python-verifier/python/.tox/py3/lib/python3.8/site-packages/pluggy/_manager.py", line 119, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/home/circleci/project/conjure-python-verifier/python/.tox/py3/lib/python3.8/site-packages/pluggy/_callers.py", line 155, in _multicall
    teardown[0].send(outcome)
  File "/home/circleci/project/conjure-python-verifier/python/.tox/py3/lib/python3.8/site-packages/_pytest/helpconfig.py", line 102, in pytest_cmdline_parse
    config: Config = outcome.get_result()
  File "/home/circleci/project/conjure-python-verifier/python/.tox/py3/lib/python3.8/site-packages/pluggy/_result.py", line 99, in get_result
    raise exc.with_traceback(exc.__traceback__)
  File "/home/circleci/project/conjure-python-verifier/python/.tox/py3/lib/python3.8/site-packages/pluggy/_callers.py", line 102, in _multicall
    res = hook_impl.function(*args)
  File "/home/circleci/project/conjure-python-verifier/python/.tox/py3/lib/python3.8/site-packages/_pytest/config/__init__.py", line 1013, in pytest_cmdline_parse
    self.parse(args)
  File "/home/circleci/project/conjure-python-verifier/python/.tox/py3/lib/python3.8/site-packages/_pytest/config/__init__.py", line 1301, in parse
    self._preparse(args, addopts=addopts)
  File "/home/circleci/project/conjure-python-verifier/python/.tox/py3/lib/python3.8/site-packages/_pytest/config/__init__.py", line 1184, in _preparse
    self.pluginmanager.load_setuptools_entrypoints("pytest11")
  File "/home/circleci/project/conjure-python-verifier/python/.tox/py3/lib/python3.8/site-packages/pluggy/_manager.py", line 414, in load_setuptools_entrypoints
    plugin = ep.load()
  File "/home/circleci/.pyenv/versions/3.8.12/lib/python3.8/importlib/metadata.py", line 77, in load
    module = import_module(match.group('module'))
  File "/home/circleci/.pyenv/versions/3.8.12/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "/home/circleci/project/conjure-python-verifier/python/.tox/py3/lib/python3.8/site-packages/_pytest/assertion/rewrite.py", line 171, in exec_module
    exec(co, module.__dict__)
  File "/home/circleci/project/conjure-python-verifier/python/.tox/py3/lib/python3.8/site-packages/pytest_pylint/plugin.py", line 14, in <module>
    from pylint.config import PYLINTRC
ImportError: cannot import name 'PYLINTRC' from 'pylint.config' (/home/circleci/project/conjure-python-verifier/python/.tox/py3/lib/python3.8/site-packages/pylint/config/__init__.py)
```

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Pin pylint to the last functioning release to unblock contributions
==COMMIT_MSG==

This is because in https://github.com/pylint-dev/pylint/commit/3318aa0c5877abd9e9d2361f8a21b8880b7a052d, the `PYLINTRC` constant was deleted.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

