### PR TITLE
Wrap indent docstring in newlines for UnionSnippet (#777)

### DIFF
--- a/changelog/@unreleased/pr-777.v2.yml
+++ b/changelog/@unreleased/pr-777.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Wrap indent docstring in newlines for UnionSnippet
+  links:
+  - https://github.com/palantir/conjure-python/pull/777

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/BeanSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/BeanSnippet.java
@@ -61,11 +61,7 @@ public interface BeanSnippet extends PythonSnippet {
     default void emit(PythonPoetWriter poetWriter) {
         poetWriter.writeIndentedLine(String.format("class %s(ConjureBeanType):", className()));
         poetWriter.increaseIndent();
-        docs().ifPresent(docs -> {
-            poetWriter.writeIndentedLine("\"\"\"");
-            poetWriter.writeIndentedLine(docs.get().trim());
-            poetWriter.writeIndentedLine("\"\"\"");
-        });
+        docs().ifPresent(poetWriter::writeDocs);
 
         poetWriter.writeLine();
 
@@ -139,11 +135,7 @@ public interface BeanSnippet extends PythonSnippet {
 
             poetWriter.increaseIndent();
             poetWriter.writeIndentedLine(String.format("# type: () -> %s", field.myPyType()));
-            field.docs().ifPresent(docs -> {
-                poetWriter.writeIndentedLine("\"\"\"");
-                poetWriter.writeIndentedLine(docs.get().trim());
-                poetWriter.writeIndentedLine("\"\"\"");
-            });
+            field.docs().ifPresent(poetWriter::writeDocs);
             poetWriter.writeIndentedLine(String.format(
                     "return self._%s", PythonIdentifierSanitizer.sanitize(field.attributeName(), PROTECTED_FIELDS)));
             poetWriter.decreaseIndent();

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/EnumSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/EnumSnippet.java
@@ -51,11 +51,7 @@ public interface EnumSnippet extends PythonSnippet {
         poetWriter.maintainingIndent(() -> {
             poetWriter.writeIndentedLine(String.format("class %s(ConjureEnumType):", className()));
             poetWriter.increaseIndent();
-            docs().ifPresent(docs -> {
-                poetWriter.writeIndentedLine("\"\"\"");
-                poetWriter.writeIndentedLine(docs.get().trim());
-                poetWriter.writeIndentedLine("\"\"\"");
-            });
+            docs().ifPresent(poetWriter::writeDocs);
 
             poetWriter.writeLine();
 

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java
@@ -109,11 +109,7 @@ public interface PythonEndpointDefinition extends Emittable {
                                     .map(PythonEndpointParam::myPyType)
                                     .collect(Collectors.toList())),
                     myPyReturnType().orElse("None"));
-            docs().ifPresent(docs -> {
-                poetWriter.writeIndentedLine("\"\"\"");
-                poetWriter.writeIndentedLine(docs.get().trim());
-                poetWriter.writeIndentedLine("\"\"\"");
-            });
+            docs().ifPresent(poetWriter::writeDocs);
 
             // replace "None" with "[]"
             for (PythonEndpointParam param : paramsWithHeader) {

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonPoetWriter.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonPoetWriter.java
@@ -19,6 +19,7 @@ package com.palantir.conjure.python.poet;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.google.errorprone.annotations.FormatMethod;
+import com.palantir.conjure.spec.Documentation;
 import java.io.PrintStream;
 
 public final class PythonPoetWriter {
@@ -94,6 +95,13 @@ public final class PythonPoetWriter {
 
     public PythonPoetWriter emit(Emittable emittable) {
         emittable.emit(this);
+        return this;
+    }
+
+    public PythonPoetWriter writeDocs(Documentation docs) {
+        writeIndentedLine("\"\"\"");
+        writeIndentedLine(docs.get().trim());
+        writeIndentedLine("\"\"\"");
         return this;
     }
 }

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonService.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonService.java
@@ -60,11 +60,7 @@ public interface PythonService extends PythonSnippet {
         poetWriter.maintainingIndent(() -> {
             poetWriter.writeIndentedLine(String.format("class %s(Service):", className()));
             poetWriter.increaseIndent();
-            docs().ifPresent(docs -> {
-                poetWriter.writeIndentedLine("\"\"\"");
-                poetWriter.writeIndentedLine(docs.get().trim());
-                poetWriter.writeIndentedLine("\"\"\"");
-            });
+            docs().ifPresent(poetWriter::writeDocs);
 
             endpointDefinitions().forEach(endpointDefinition -> {
                 poetWriter.writeLine();

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
@@ -87,8 +87,7 @@ public interface UnionSnippet extends PythonSnippet {
         poetWriter.maintainingIndent(() -> {
             poetWriter.writeIndentedLine(String.format("class %s(ConjureUnionType):", className()));
             poetWriter.increaseIndent();
-            docs().ifPresent(docs -> poetWriter.writeIndentedLine(
-                    String.format("\"\"\"%s\"\"\"", docs.get().trim())));
+            docs().ifPresent(poetWriter::writeDocs);
 
             options()
                     .forEach(option -> poetWriter.writeIndentedLine(

--- a/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
@@ -1511,7 +1511,9 @@ product_StringExample.__module__ = "package_name.product"
 
 
 class product_UnionTypeExample(ConjureUnionType):
-    """A type which can either be a StringExample, a set of strings, or an integer."""
+    """
+    A type which can either be a StringExample, a set of strings, or an integer.
+    """
     _string_example = None # type: Optional[product_StringExample]
     _set = None # type: Optional[List[str]]
     _this_field_is_an_integer = None # type: Optional[int]


### PR DESCRIPTION
Backport of https://github.com/palantir/conjure-python/pull/777

## Before this PR
The `UnionSnippet.emit(PythonPoetWriter poetWriter)` method parses conjure class definitions into python code bindings. As part of the process, it extracts `docs` components from the apis and wraps them in the python docstring format, which is the triple-quote `"""`.

If a docstring terminates with a `"` (which it shouldn't), that would cause a set of 4 consecutives `"`, which is invalid python and that will cause errors when reading from these files.
For example, if I define my conjure api like
```
FaultyType:
  docs: this will say "ERROR"
  union:
    something: integer
    somethingElse: string
```
this will cause the following error when reading the generated conjure python bindings:
```
File "tmp.py", line 10
      """this will say "ERROR""""
                                                  ^
  SyntaxError: EOL while scanning string literal
```

## After this PR
Fix up UnionSnippet to have newlines wrapping the content and extract the doc-writing into a separate method being reused across all cases.

==COMMIT_MSG==
Wrap indent docstring in newlines for UnionSnippet
==COMMIT_MSG==

## Possible downsides?
The pythonic way of doing docstrings has them in the format
```
"""Docstring
"""
```
but we currently do
```
"""
Docstring
"""
```
I will change that in a separate PR, this is a more time-sensitive fix.

