### PR TITLE
Use pythonic docstyle for conjure types' docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,14 +53,12 @@ Example service interface: [TestService](https://github.com/palantir/conjure-pyt
 
 ```python
 class TestService(Service):
-    """
-    A Markdown description of the service. "Might end with quotes"
+    """A Markdown description of the service. "Might end with quotes"
     """
 
     def get_file_systems(self, auth_header):
         # type: (str) -> Dict[str, BackingFileSystem]
-        """
-        Returns a mapping from file system id to backing file system configuration.
+        """Returns a mapping from file system id to backing file system configuration.
         """
 
         _headers = {

--- a/changelog/@unreleased/pr-780.v2.yml
+++ b/changelog/@unreleased/pr-780.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Use pythonic docstyle for conjure types' docs
+  links:
+  - https://github.com/palantir/conjure-python/pull/780

--- a/changelog/@unreleased/pr-780.v2.yml
+++ b/changelog/@unreleased/pr-780.v2.yml
@@ -1,5 +1,6 @@
 type: improvement
 improvement:
-  description: Use pythonic docstyle for conjure types' docs
+  description: Use pythonic docstyle for conjure types' docs and disallow any sequence
+    of `"""` within
   links:
   - https://github.com/palantir/conjure-python/pull/780

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonPoetWriter.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonPoetWriter.java
@@ -98,9 +98,12 @@ public final class PythonPoetWriter {
         return this;
     }
 
+    /**
+     * Write docs in pythonic style, with triple quotes leading the docstring and newline preceding the closing triple.
+     * Replaces all inner occurence of triple quotes with a triple single quote to avoid closing the docstring early.
+     */
     public PythonPoetWriter writeDocs(Documentation docs) {
-        writeIndentedLine("\"\"\"");
-        writeIndentedLine(docs.get().trim());
+        writeIndentedLine("\"\"\"" + docs.get().replace("\"\"\"", "'''").trim());
         writeIndentedLine("\"\"\"");
         return this;
     }

--- a/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
@@ -21,13 +21,11 @@ from typing import (
 )
 
 class another_TestService(Service):
-    """
-    A Markdown description of the service. "Might end with quotes"
+    """A Markdown description of the service. "Might end with quotes"
     """
 
     def get_file_systems(self, auth_header: str) -> Dict[str, "product_datasets_BackingFileSystem"]:
-        """
-        Returns a mapping from file system id to backing file system configuration.
+        """Returns a mapping from file system id to backing file system configuration.
         """
 
         _headers: Dict[str, Any] = {
@@ -235,8 +233,7 @@ class another_TestService(Service):
         return _decoder.decode(_response.json(), List[str], self._return_none_for_unknown_union_types)
 
     def get_branches_deprecated(self, auth_header: str, dataset_rid: str) -> List[str]:
-        """
-        Gets all branches of this dataset.
+        """Gets all branches of this dataset.
         """
 
         _headers: Dict[str, Any] = {
@@ -497,8 +494,7 @@ class product_datasets_BackingFileSystem(ConjureBeanType):
 
     @builtins.property
     def file_system_id(self) -> str:
-        """
-        The name by which this file system is identified.
+        """The name by which this file system is identified.
         """
         return self._file_system_id
 
@@ -537,8 +533,7 @@ class product_datasets_Dataset(ConjureBeanType):
 
     @builtins.property
     def rid(self) -> str:
-        """
-        Uniquely identifies this dataset.
+        """Uniquely identifies this dataset.
         """
         return self._rid
 

--- a/conjure-python-core/src/test/resources/types/example-types.yml
+++ b/conjure-python-core/src/test/resources/types/example-types.yml
@@ -134,6 +134,11 @@ types:
           new: integer
           interface: integer
           property: integer
+      SimpleTypeWithWeirdDocExample:
+        docs: \"Weird \"\"\" quotes \"everywhere\"also \"\"at the end\"
+        fields:
+          field:
+            type: string
       EmptyObjectExample:
         fields: {}
       AliasAsMapKeyExample:

--- a/conjure-python-core/src/test/resources/types/example-types.yml
+++ b/conjure-python-core/src/test/resources/types/example-types.yml
@@ -135,7 +135,7 @@ types:
           interface: integer
           property: integer
       SimpleTypeWithWeirdDocExample:
-        docs: "Weird """ quotes "everywhere"also ""at the end"
+        docs: Weird """ quotes "everywhere"also ""at the end"
         fields:
           field:
             type: string

--- a/conjure-python-core/src/test/resources/types/example-types.yml
+++ b/conjure-python-core/src/test/resources/types/example-types.yml
@@ -135,7 +135,7 @@ types:
           interface: integer
           property: integer
       SimpleTypeWithWeirdDocExample:
-        docs: \"Weird \"\"\" quotes \"everywhere\"also \"\"at the end\"
+        docs: "Weird """ quotes "everywhere"also ""at the end"
         fields:
           field:
             type: string

--- a/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
@@ -832,7 +832,7 @@ product_DoubleExample.__module__ = "package_name.product"
 
 
 class product_SimpleTypeWithWeirdDocExample(ConjureBeanType):
-    """"Weird ''' quotes "everywhere"also ""at the end"
+    """Weird ''' quotes "everywhere"also ""at the end"
     """
     @builtins.classmethod
     def _fields(cls) -> Dict[str, ConjureFieldDefinition]:

--- a/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
@@ -832,7 +832,7 @@ product_DoubleExample.__module__ = "package_name.product"
 
 
 class product_SimpleTypeWithWeirdDocExample(ConjureBeanType):
-    """""Weird ''' quotes "everywhere"also ""at the end"
+    """"Weird ''' quotes "everywhere"also ""at the end"
     """
     @builtins.classmethod
     def _fields(cls) -> Dict[str, ConjureFieldDefinition]:

--- a/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
@@ -26,13 +26,11 @@ from typing import (
 )
 
 class another_TestService(Service):
-    """
-    A Markdown description of the service. "Might end with quotes"
+    """A Markdown description of the service. "Might end with quotes"
     """
 
     def get_file_systems(self, auth_header: str) -> Dict[str, "product_datasets_BackingFileSystem"]:
-        """
-        Returns a mapping from file system id to backing file system configuration.
+        """Returns a mapping from file system id to backing file system configuration.
         """
 
         _headers: Dict[str, Any] = {
@@ -240,8 +238,7 @@ class another_TestService(Service):
         return _decoder.decode(_response.json(), List[str], self._return_none_for_unknown_union_types)
 
     def get_branches_deprecated(self, auth_header: str, dataset_rid: str) -> List[str]:
-        """
-        Gets all branches of this dataset.
+        """Gets all branches of this dataset.
         """
 
         _headers: Dict[str, Any] = {
@@ -851,8 +848,7 @@ product_EmptyObjectExample.__module__ = "package_name.product"
 
 
 class product_EnumExample(ConjureEnumType):
-    """
-    This enumerates the numbers 1:2.
+    """This enumerates the numbers 1:2.
     """
 
     ONE = 'ONE'
@@ -1004,57 +1000,49 @@ class product_ManyFieldExample(ConjureBeanType):
 
     @builtins.property
     def string(self) -> str:
-        """
-        docs for string field
+        """docs for string field
         """
         return self._string
 
     @builtins.property
     def integer(self) -> int:
-        """
-        docs for integer field
+        """docs for integer field
         """
         return self._integer
 
     @builtins.property
     def double_value(self) -> float:
-        """
-        docs for doubleValue field
+        """docs for doubleValue field
         """
         return self._double_value
 
     @builtins.property
     def optional_item(self) -> Optional[str]:
-        """
-        docs for optionalItem field
+        """docs for optionalItem field
         """
         return self._optional_item
 
     @builtins.property
     def items(self) -> List[str]:
-        """
-        docs for items field
+        """docs for items field
         """
         return self._items
 
     @builtins.property
     def set(self) -> List[str]:
-        """
-        docs for set field
+        """docs for set field
         """
         return self._set
 
     @builtins.property
     def map(self) -> Dict[str, str]:
-        """
-        docs for map field
+        """docs for map field
         """
         return self._map
 
     @builtins.property
     def alias(self) -> str:
-        """
-        docs for alias field
+        """docs for alias field
         """
         return self._alias
 
@@ -1388,8 +1376,7 @@ product_StringExample.__module__ = "package_name.product"
 
 
 class product_UnionTypeExample(ConjureUnionType):
-    """
-    A type which can either be a StringExample, a set of strings, or an integer.
+    """A type which can either be a StringExample, a set of strings, or an integer.
     """
     _string_example: Optional["product_StringExample"] = None
     _set: Optional[List[str]] = None
@@ -1497,8 +1484,7 @@ class product_UnionTypeExample(ConjureUnionType):
 
     @builtins.property
     def string_example(self) -> Optional["product_StringExample"]:
-        """
-        Docs for when UnionTypeExample is of type StringExample.
+        """Docs for when UnionTypeExample is of type StringExample.
         """
         return self._string_example
 
@@ -1715,8 +1701,7 @@ class product_datasets_BackingFileSystem(ConjureBeanType):
 
     @builtins.property
     def file_system_id(self) -> str:
-        """
-        The name by which this file system is identified.
+        """The name by which this file system is identified.
         """
         return self._file_system_id
 
@@ -1755,8 +1740,7 @@ class product_datasets_Dataset(ConjureBeanType):
 
     @builtins.property
     def rid(self) -> str:
-        """
-        Uniquely identifies this dataset.
+        """Uniquely identifies this dataset.
         """
         return self._rid
 

--- a/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
@@ -831,6 +831,29 @@ product_DoubleExample.__qualname__ = "DoubleExample"
 product_DoubleExample.__module__ = "package_name.product"
 
 
+class product_SimpleTypeWithWeirdDocExample(ConjureBeanType):
+    """""Weird ''' quotes "everywhere"also ""at the end"
+    """
+    @builtins.classmethod
+    def _fields(cls) -> Dict[str, ConjureFieldDefinition]:
+        return {
+            'field': ConjureFieldDefinition('field', str)
+        }
+
+    __slots__: List[str] = ['_field']
+
+    def __init__(self, field: str) -> None:
+        self._field = field
+
+    @builtins.property
+    def field(self) -> str:
+        return self._field
+
+product_SimpleTypeWithWeirdDocExample.__name__ = "SimpleTypeWithWeirdDocExample"
+product_SimpleTypeWithWeirdDocExample.__qualname__ = "SimpleTypeWithWeirdDocExample"
+product_SimpleTypeWithWeirdDocExample.__module__ = "package_name.product"
+
+
 class product_EmptyObjectExample(ConjureBeanType):
 
     @builtins.classmethod

--- a/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
@@ -831,31 +831,6 @@ product_DoubleExample.__qualname__ = "DoubleExample"
 product_DoubleExample.__module__ = "package_name.product"
 
 
-class product_SimpleTypeWithWeirdDocExample(ConjureBeanType):
-    """Weird ''' quotes "everywhere"also ""at the end"
-    """
-
-    @builtins.classmethod
-    def _fields(cls) -> Dict[str, ConjureFieldDefinition]:
-        return {
-            'field': ConjureFieldDefinition('field', str)
-        }
-
-    __slots__: List[str] = ['_field']
-
-    def __init__(self, field: str) -> None:
-        self._field = field
-
-    @builtins.property
-    def field(self) -> str:
-        return self._field
-
-
-product_SimpleTypeWithWeirdDocExample.__name__ = "SimpleTypeWithWeirdDocExample"
-product_SimpleTypeWithWeirdDocExample.__qualname__ = "SimpleTypeWithWeirdDocExample"
-product_SimpleTypeWithWeirdDocExample.__module__ = "package_name.product"
-
-
 class product_EmptyObjectExample(ConjureBeanType):
 
     @builtins.classmethod
@@ -1375,6 +1350,31 @@ class product_SetExample(ConjureBeanType):
 product_SetExample.__name__ = "SetExample"
 product_SetExample.__qualname__ = "SetExample"
 product_SetExample.__module__ = "package_name.product"
+
+
+class product_SimpleTypeWithWeirdDocExample(ConjureBeanType):
+    """Weird ''' quotes "everywhere"also ""at the end"
+    """
+
+    @builtins.classmethod
+    def _fields(cls) -> Dict[str, ConjureFieldDefinition]:
+        return {
+            'field': ConjureFieldDefinition('field', str)
+        }
+
+    __slots__: List[str] = ['_field']
+
+    def __init__(self, field: str) -> None:
+        self._field = field
+
+    @builtins.property
+    def field(self) -> str:
+        return self._field
+
+
+product_SimpleTypeWithWeirdDocExample.__name__ = "SimpleTypeWithWeirdDocExample"
+product_SimpleTypeWithWeirdDocExample.__qualname__ = "SimpleTypeWithWeirdDocExample"
+product_SimpleTypeWithWeirdDocExample.__module__ = "package_name.product"
 
 
 class product_StringExample(ConjureBeanType):

--- a/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
@@ -850,6 +850,7 @@ class product_SimpleTypeWithWeirdDocExample(ConjureBeanType):
     def field(self) -> str:
         return self._field
 
+
 product_SimpleTypeWithWeirdDocExample.__name__ = "SimpleTypeWithWeirdDocExample"
 product_SimpleTypeWithWeirdDocExample.__qualname__ = "SimpleTypeWithWeirdDocExample"
 product_SimpleTypeWithWeirdDocExample.__module__ = "package_name.product"

--- a/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
@@ -834,6 +834,7 @@ product_DoubleExample.__module__ = "package_name.product"
 class product_SimpleTypeWithWeirdDocExample(ConjureBeanType):
     """Weird ''' quotes "everywhere"also ""at the end"
     """
+
     @builtins.classmethod
     def _fields(cls) -> Dict[str, ConjureFieldDefinition]:
         return {

--- a/conjure-python-core/src/test/resources/types/expected/package_name/product/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/product/__init__.py
@@ -39,6 +39,7 @@ from .._impl import (
     product_SafeLongAliasExample as SafeLongAliasExample,
     product_SafeLongExample as SafeLongExample,
     product_SetExample as SetExample,
+    product_SimpleTypeWithWeirdDocExample as SimpleTypeWithWeirdDocExample,
     product_StringAliasExample as StringAliasExample,
     product_StringExample as StringExample,
     product_UnionTypeExample as UnionTypeExample,


### PR DESCRIPTION
## Before this PR
The docstring generation for python docs is outputting them in the format
```
"""
Docs
"""
```
While the proper pythonic way would be
```
"""Docs
"""
```

## After this PR
Adapt docs generation to follow python docstyle.
In addition to that, disallow any sequence of `"""` within the generated code to avoid accidentally escaping the doc string

==COMMIT_MSG==
Use pythonic docstyle for conjure types' docs and disallow any sequence of `"""` within
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

