### PR TITLE
Properly handle enums in path/query/header params and URL encode path params

### DIFF
--- a/changelog/@unreleased/pr-927.v2.yml
+++ b/changelog/@unreleased/pr-927.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Properly handle enums in path/query/header params and URL encode path
+    params
+  links:
+  - https://github.com/palantir/conjure-python/pull/927

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/ConjurePythonGenerator.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/ConjurePythonGenerator.java
@@ -150,10 +150,10 @@ public final class ConjurePythonGenerator {
         List<PythonSnippet> snippets = new ArrayList<>();
         snippets.addAll(conjureDefinition.getTypes().stream()
                 .map(beanGenerator::generateType)
-                .collect(Collectors.toList()));
+                .toList());
         snippets.addAll(conjureDefinition.getServices().stream()
                 .map(clientGenerator::generateClient)
-                .collect(Collectors.toList()));
+                .toList());
 
         Map<PythonPackage, List<PythonSnippet>> snippetsByPackage =
                 snippets.stream().collect(Collectors.groupingBy(PythonSnippet::pythonPackage));

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java
@@ -38,6 +38,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 public interface PythonEndpointDefinition extends Emittable {
+    String AUTH_HEADER_PYTHON_PARAM_NAME = "auth_header";
 
     String pythonMethodName();
 
@@ -78,7 +79,7 @@ public interface PythonEndpointDefinition extends Emittable {
                     ? ImmutableList.<PythonEndpointParam>builder()
                             .add(PythonEndpointParam.builder()
                                     .paramName("authHeader")
-                                    .pythonParamName("auth_header")
+                                    .pythonParamName(AUTH_HEADER_PYTHON_PARAM_NAME)
                                     .myPyType("str")
                                     .isOptional(false)
                                     .isCollection(false)
@@ -117,6 +118,8 @@ public interface PythonEndpointDefinition extends Emittable {
                 }
             }
 
+            poetWriter.writeIndentedLine("_conjure_encoder = ConjureEncoder()");
+
             // header
             poetWriter.writeLine();
             poetWriter.writeIndentedLine("_headers: Dict[str, Any] = {");
@@ -137,13 +140,16 @@ public interface PythonEndpointDefinition extends Emittable {
             paramsWithHeader.stream()
                     .filter(param -> param.paramType().accept(ParameterTypeVisitor.IS_HEADER))
                     .forEach(param -> {
-                        poetWriter.writeIndentedLine(
-                                "'%s': %s,",
-                                param.paramType()
-                                        .accept(ParameterTypeVisitor.HEADER)
-                                        .getParamId()
-                                        .get(),
-                                param.pythonParamName());
+                        String headerParamId = param.paramType()
+                                .accept(ParameterTypeVisitor.HEADER)
+                                .getParamId()
+                                .get();
+                        if (param.pythonParamName().equals(AUTH_HEADER_PYTHON_PARAM_NAME)) {
+                            poetWriter.writeIndentedLine("'%s': %s,", headerParamId, param.pythonParamName());
+                        } else {
+                            poetWriter.writeIndentedLine(
+                                    "'%s': _conjure_encoder.default(%s),", headerParamId, param.pythonParamName());
+                        }
                     });
             poetWriter.decreaseIndent();
             poetWriter.writeIndentedLine("}");
@@ -156,7 +162,7 @@ public interface PythonEndpointDefinition extends Emittable {
                     .filter(param -> param.paramType().accept(ParameterTypeVisitor.IS_QUERY))
                     .forEach(param -> {
                         poetWriter.writeIndentedLine(
-                                "'%s': %s,",
+                                "'%s': _conjure_encoder.default(%s),",
                                 param.paramType()
                                         .accept(ParameterTypeVisitor.QUERY)
                                         .getParamId()
@@ -168,13 +174,15 @@ public interface PythonEndpointDefinition extends Emittable {
 
             // path params
             poetWriter.writeLine();
-            poetWriter.writeIndentedLine("_path_params: Dict[str, Any] = {");
+            poetWriter.writeIndentedLine("_path_params: Dict[str, str] = {");
             poetWriter.increaseIndent();
             // TODO(qchen): no need for param name twice?
             paramsWithHeader.stream()
                     .filter(param -> param.paramType().accept(ParameterTypeVisitor.IS_PATH))
                     .forEach(param -> {
-                        poetWriter.writeIndentedLine("'%s': %s,", param.paramName(), param.pythonParamName());
+                        poetWriter.writeIndentedLine(
+                                "'%s': quote(str(_conjure_encoder.default(%s)), safe=''),",
+                                param.paramName(), param.pythonParamName());
                     });
             poetWriter.decreaseIndent();
             poetWriter.writeIndentedLine("}");
@@ -183,7 +191,7 @@ public interface PythonEndpointDefinition extends Emittable {
                 if (!isRequestBinary()) {
                     poetWriter.writeLine();
                     poetWriter.writeIndentedLine(
-                            "_json: Any = ConjureEncoder().default(%s)",
+                            "_json: Any = _conjure_encoder.default(%s)",
                             bodyParam.get().pythonParamName());
                 } else {
                     poetWriter.writeLine();

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java
@@ -160,15 +160,13 @@ public interface PythonEndpointDefinition extends Emittable {
             poetWriter.increaseIndent();
             paramsWithHeader.stream()
                     .filter(param -> param.paramType().accept(ParameterTypeVisitor.IS_QUERY))
-                    .forEach(param -> {
-                        poetWriter.writeIndentedLine(
-                                "'%s': _conjure_encoder.default(%s),",
-                                param.paramType()
-                                        .accept(ParameterTypeVisitor.QUERY)
-                                        .getParamId()
-                                        .get(),
-                                param.pythonParamName());
-                    });
+                    .forEach(param -> poetWriter.writeIndentedLine(
+                            "'%s': _conjure_encoder.default(%s),",
+                            param.paramType()
+                                    .accept(ParameterTypeVisitor.QUERY)
+                                    .getParamId()
+                                    .get(),
+                            param.pythonParamName()));
             poetWriter.decreaseIndent();
             poetWriter.writeIndentedLine("}");
 
@@ -179,11 +177,9 @@ public interface PythonEndpointDefinition extends Emittable {
             // TODO(qchen): no need for param name twice?
             paramsWithHeader.stream()
                     .filter(param -> param.paramType().accept(ParameterTypeVisitor.IS_PATH))
-                    .forEach(param -> {
-                        poetWriter.writeIndentedLine(
-                                "'%s': quote(str(_conjure_encoder.default(%s)), safe=''),",
-                                param.paramName(), param.pythonParamName());
-                    });
+                    .forEach(param -> poetWriter.writeIndentedLine(
+                            "'%s': quote(str(_conjure_encoder.default(%s)), safe=''),",
+                            param.paramName(), param.pythonParamName()));
             poetWriter.decreaseIndent();
             poetWriter.writeIndentedLine("}");
 

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonService.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonService.java
@@ -41,6 +41,10 @@ public interface PythonService extends PythonSnippet {
                     .moduleSpecifier(ImportTypeVisitor.TYPING)
                     // Used by Endpoints
                     .addNamedImports(NamedImport.of("Dict"), NamedImport.of("Any"))
+                    .build(),
+            PythonImport.builder()
+                    .moduleSpecifier("urllib.parse")
+                    .addNamedImports(NamedImport.of("quote"))
                     .build());
 
     @Override

--- a/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
@@ -5,6 +5,7 @@ from conjure_python_client import (
     ConjureBeanType,
     ConjureDecoder,
     ConjureEncoder,
+    ConjureEnumType,
     ConjureFieldDefinition,
     OptionalTypeWrapper,
     Service,
@@ -19,6 +20,9 @@ from typing import (
     Optional,
     Set,
 )
+from urllib.parse import (
+    quote,
+)
 
 class another_TestService(Service):
     """A Markdown description of the service. "Might end with quotes"
@@ -27,6 +31,7 @@ class another_TestService(Service):
     def get_file_systems(self, auth_header: str) -> Dict[str, "product_datasets_BackingFileSystem"]:
         """Returns a mapping from file system id to backing file system configuration.
         """
+        _conjure_encoder = ConjureEncoder()
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
@@ -36,7 +41,7 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
+        _path_params: Dict[str, str] = {
         }
 
         _json: Any = None
@@ -55,21 +60,22 @@ class another_TestService(Service):
         return _decoder.decode(_response.json(), Dict[str, product_datasets_BackingFileSystem], self._return_none_for_unknown_union_types)
 
     def create_dataset(self, auth_header: str, request: "product_CreateDatasetRequest", test_header_arg: str) -> "product_datasets_Dataset":
+        _conjure_encoder = ConjureEncoder()
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
             'Content-Type': 'application/json',
             'Authorization': auth_header,
-            'Test-Header': test_header_arg,
+            'Test-Header': _conjure_encoder.default(test_header_arg),
         }
 
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
+        _path_params: Dict[str, str] = {
         }
 
-        _json: Any = ConjureEncoder().default(request)
+        _json: Any = _conjure_encoder.default(request)
 
         _path = '/catalog/datasets'
         _path = _path.format(**_path_params)
@@ -85,6 +91,7 @@ class another_TestService(Service):
         return _decoder.decode(_response.json(), product_datasets_Dataset, self._return_none_for_unknown_union_types)
 
     def get_dataset(self, auth_header: str, dataset_rid: str) -> Optional["product_datasets_Dataset"]:
+        _conjure_encoder = ConjureEncoder()
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
@@ -94,8 +101,8 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
-            'datasetRid': dataset_rid,
+        _path_params: Dict[str, str] = {
+            'datasetRid': quote(str(_conjure_encoder.default(dataset_rid)), safe=''),
         }
 
         _json: Any = None
@@ -114,6 +121,7 @@ class another_TestService(Service):
         return None if _response.status_code == 204 else _decoder.decode(_response.json(), OptionalTypeWrapper[product_datasets_Dataset], self._return_none_for_unknown_union_types)
 
     def get_raw_data(self, auth_header: str, dataset_rid: str) -> Any:
+        _conjure_encoder = ConjureEncoder()
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/octet-stream',
@@ -123,8 +131,8 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
-            'datasetRid': dataset_rid,
+        _path_params: Dict[str, str] = {
+            'datasetRid': quote(str(_conjure_encoder.default(dataset_rid)), safe=''),
         }
 
         _json: Any = None
@@ -145,6 +153,7 @@ class another_TestService(Service):
         return _raw
 
     def maybe_get_raw_data(self, auth_header: str, dataset_rid: str) -> Optional[Any]:
+        _conjure_encoder = ConjureEncoder()
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
@@ -154,8 +163,8 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
-            'datasetRid': dataset_rid,
+        _path_params: Dict[str, str] = {
+            'datasetRid': quote(str(_conjure_encoder.default(dataset_rid)), safe=''),
         }
 
         _json: Any = None
@@ -174,6 +183,7 @@ class another_TestService(Service):
         return None if _response.status_code == 204 else _decoder.decode(_response.json(), OptionalTypeWrapper[BinaryType], self._return_none_for_unknown_union_types)
 
     def upload_raw_data(self, auth_header: str, input: Any) -> None:
+        _conjure_encoder = ConjureEncoder()
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
@@ -184,7 +194,7 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
+        _path_params: Dict[str, str] = {
         }
 
         _data: Any = input
@@ -201,20 +211,54 @@ class another_TestService(Service):
 
         return
 
+    def upload_python_package(self, auth_header: str, upload_type: "product_UploadType", upload_type_header: "product_UploadType", upload_types_query: List["product_UploadType"] = None, upload_type_body: Optional["product_UploadType"] = None) -> None:
+        upload_types_query = upload_types_query if upload_types_query is not None else []
+        _conjure_encoder = ConjureEncoder()
+
+        _headers: Dict[str, Any] = {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+            'Authorization': auth_header,
+            'Upload-Type': _conjure_encoder.default(upload_type_header),
+        }
+
+        _params: Dict[str, Any] = {
+            'uploadTypesQuery': _conjure_encoder.default(upload_types_query),
+        }
+
+        _path_params: Dict[str, str] = {
+            'uploadType': quote(str(_conjure_encoder.default(upload_type)), safe=''),
+        }
+
+        _json: Any = _conjure_encoder.default(upload_type_body)
+
+        _path = '/catalog/data/python/{uploadType}'
+        _path = _path.format(**_path_params)
+
+        _response: Response = self._request(
+            'POST',
+            self._uri + _path,
+            params=_params,
+            headers=_headers,
+            json=_json)
+
+        return
+
     def get_branches(self, auth_header: str, dataset_rid: str, message: Optional[str] = None, page_size: Optional[int] = None) -> List[str]:
+        _conjure_encoder = ConjureEncoder()
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
             'Authorization': auth_header,
-            'Special-Message': message,
+            'Special-Message': _conjure_encoder.default(message),
         }
 
         _params: Dict[str, Any] = {
-            'pageSize': page_size,
+            'pageSize': _conjure_encoder.default(page_size),
         }
 
-        _path_params: Dict[str, Any] = {
-            'datasetRid': dataset_rid,
+        _path_params: Dict[str, str] = {
+            'datasetRid': quote(str(_conjure_encoder.default(dataset_rid)), safe=''),
         }
 
         _json: Any = None
@@ -235,6 +279,7 @@ class another_TestService(Service):
     def get_branches_deprecated(self, auth_header: str, dataset_rid: str) -> List[str]:
         """Gets all branches of this dataset.
         """
+        _conjure_encoder = ConjureEncoder()
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
@@ -244,8 +289,8 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
-            'datasetRid': dataset_rid,
+        _path_params: Dict[str, str] = {
+            'datasetRid': quote(str(_conjure_encoder.default(dataset_rid)), safe=''),
         }
 
         _json: Any = None
@@ -264,6 +309,7 @@ class another_TestService(Service):
         return _decoder.decode(_response.json(), List[str], self._return_none_for_unknown_union_types)
 
     def resolve_branch(self, auth_header: str, branch: str, dataset_rid: str) -> Optional[str]:
+        _conjure_encoder = ConjureEncoder()
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
@@ -273,9 +319,9 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
-            'datasetRid': dataset_rid,
-            'branch': branch,
+        _path_params: Dict[str, str] = {
+            'datasetRid': quote(str(_conjure_encoder.default(dataset_rid)), safe=''),
+            'branch': quote(str(_conjure_encoder.default(branch)), safe=''),
         }
 
         _json: Any = None
@@ -294,6 +340,7 @@ class another_TestService(Service):
         return None if _response.status_code == 204 else _decoder.decode(_response.json(), OptionalTypeWrapper[str], self._return_none_for_unknown_union_types)
 
     def test_param(self, auth_header: str, dataset_rid: str) -> Optional[str]:
+        _conjure_encoder = ConjureEncoder()
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
@@ -303,8 +350,8 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
-            'datasetRid': dataset_rid,
+        _path_params: Dict[str, str] = {
+            'datasetRid': quote(str(_conjure_encoder.default(dataset_rid)), safe=''),
         }
 
         _json: Any = None
@@ -325,6 +372,7 @@ class another_TestService(Service):
     def test_query_params(self, auth_header: str, implicit: str, nonlocal_: int, something: str, list: List[int] = None, set: List[int] = None) -> int:
         list = list if list is not None else []
         set = set if set is not None else []
+        _conjure_encoder = ConjureEncoder()
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
@@ -332,14 +380,14 @@ class another_TestService(Service):
         }
 
         _params: Dict[str, Any] = {
-            'different': something,
-            'implicit': implicit,
-            'list': list,
-            'set': set,
-            'nonlocal': nonlocal_,
+            'different': _conjure_encoder.default(something),
+            'implicit': _conjure_encoder.default(implicit),
+            'list': _conjure_encoder.default(list),
+            'set': _conjure_encoder.default(set),
+            'nonlocal': _conjure_encoder.default(nonlocal_),
         }
 
-        _path_params: Dict[str, Any] = {
+        _path_params: Dict[str, str] = {
         }
 
         _json: Any = None
@@ -358,6 +406,7 @@ class another_TestService(Service):
         return _decoder.decode(_response.json(), int, self._return_none_for_unknown_union_types)
 
     def test_boolean(self, auth_header: str) -> bool:
+        _conjure_encoder = ConjureEncoder()
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
@@ -367,7 +416,7 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
+        _path_params: Dict[str, str] = {
         }
 
         _json: Any = None
@@ -386,6 +435,7 @@ class another_TestService(Service):
         return _decoder.decode(_response.json(), bool, self._return_none_for_unknown_union_types)
 
     def test_double(self, auth_header: str) -> float:
+        _conjure_encoder = ConjureEncoder()
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
@@ -395,7 +445,7 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
+        _path_params: Dict[str, str] = {
         }
 
         _json: Any = None
@@ -414,6 +464,7 @@ class another_TestService(Service):
         return _decoder.decode(_response.json(), float, self._return_none_for_unknown_union_types)
 
     def test_integer(self, auth_header: str) -> int:
+        _conjure_encoder = ConjureEncoder()
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
@@ -423,7 +474,7 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
+        _path_params: Dict[str, str] = {
         }
 
         _json: Any = None
@@ -474,6 +525,24 @@ class product_CreateDatasetRequest(ConjureBeanType):
 product_CreateDatasetRequest.__name__ = "CreateDatasetRequest"
 product_CreateDatasetRequest.__qualname__ = "CreateDatasetRequest"
 product_CreateDatasetRequest.__module__ = "package_name.product"
+
+
+class product_UploadType(ConjureEnumType):
+
+    PYPI = 'PYPI'
+    '''PYPI'''
+    CONDA = 'CONDA'
+    '''CONDA'''
+    UNKNOWN = 'UNKNOWN'
+    '''UNKNOWN'''
+
+    def __reduce_ex__(self, proto):
+        return self.__class__, (self.name,)
+
+
+product_UploadType.__name__ = "UploadType"
+product_UploadType.__qualname__ = "UploadType"
+product_UploadType.__module__ = "package_name.product"
 
 
 class product_datasets_BackingFileSystem(ConjureBeanType):

--- a/conjure-python-core/src/test/resources/services/expected/package_name/product/__init__.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/product/__init__.py
@@ -1,9 +1,11 @@
 # coding=utf-8
 from .._impl import (
     product_CreateDatasetRequest as CreateDatasetRequest,
+    product_UploadType as UploadType,
 )
 
 __all__ = [
     'CreateDatasetRequest',
+    'UploadType',
 ]
 

--- a/conjure-python-core/src/test/resources/types/example-service.yml
+++ b/conjure-python-core/src/test/resources/types/example-service.yml
@@ -47,6 +47,11 @@ types:
         package: com.palantir.package.name
         alias: string
 
+      UploadType:
+        values:
+          - value: PYPI
+          - value: CONDA
+
 services:
   TestService:
     name: Test Service
@@ -107,6 +112,25 @@ services:
         args:
           input:
             type: binary
+            param-type: body
+
+      uploadPythonPackage:
+        http: POST /data/python/{uploadType}
+        args:
+          uploadType: UploadType
+          uploadTypeHeader:
+            type: UploadType
+            param-id: Upload-Type
+            param-type: header
+            markers:
+              - Safe
+          uploadTypesQuery:
+            docs: |
+              The upload types of the python package.
+            type: list<UploadType>
+            param-type: query
+          uploadTypeBody:
+            type: optional<UploadType>
             param-type: body
 
       getBranches:

--- a/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
@@ -24,6 +24,9 @@ from typing import (
     Optional,
     Set,
 )
+from urllib.parse import (
+    quote,
+)
 
 class another_TestService(Service):
     """A Markdown description of the service. "Might end with quotes"
@@ -32,6 +35,7 @@ class another_TestService(Service):
     def get_file_systems(self, auth_header: str) -> Dict[str, "product_datasets_BackingFileSystem"]:
         """Returns a mapping from file system id to backing file system configuration.
         """
+        _conjure_encoder = ConjureEncoder()
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
@@ -41,7 +45,7 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
+        _path_params: Dict[str, str] = {
         }
 
         _json: Any = None
@@ -60,21 +64,22 @@ class another_TestService(Service):
         return _decoder.decode(_response.json(), Dict[str, product_datasets_BackingFileSystem], self._return_none_for_unknown_union_types)
 
     def create_dataset(self, auth_header: str, request: "product_CreateDatasetRequest", test_header_arg: str) -> "product_datasets_Dataset":
+        _conjure_encoder = ConjureEncoder()
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
             'Content-Type': 'application/json',
             'Authorization': auth_header,
-            'Test-Header': test_header_arg,
+            'Test-Header': _conjure_encoder.default(test_header_arg),
         }
 
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
+        _path_params: Dict[str, str] = {
         }
 
-        _json: Any = ConjureEncoder().default(request)
+        _json: Any = _conjure_encoder.default(request)
 
         _path = '/catalog/datasets'
         _path = _path.format(**_path_params)
@@ -90,6 +95,7 @@ class another_TestService(Service):
         return _decoder.decode(_response.json(), product_datasets_Dataset, self._return_none_for_unknown_union_types)
 
     def get_dataset(self, auth_header: str, dataset_rid: str) -> Optional["product_datasets_Dataset"]:
+        _conjure_encoder = ConjureEncoder()
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
@@ -99,8 +105,8 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
-            'datasetRid': dataset_rid,
+        _path_params: Dict[str, str] = {
+            'datasetRid': quote(str(_conjure_encoder.default(dataset_rid)), safe=''),
         }
 
         _json: Any = None
@@ -119,6 +125,7 @@ class another_TestService(Service):
         return None if _response.status_code == 204 else _decoder.decode(_response.json(), OptionalTypeWrapper[product_datasets_Dataset], self._return_none_for_unknown_union_types)
 
     def get_raw_data(self, auth_header: str, dataset_rid: str) -> Any:
+        _conjure_encoder = ConjureEncoder()
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/octet-stream',
@@ -128,8 +135,8 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
-            'datasetRid': dataset_rid,
+        _path_params: Dict[str, str] = {
+            'datasetRid': quote(str(_conjure_encoder.default(dataset_rid)), safe=''),
         }
 
         _json: Any = None
@@ -150,6 +157,7 @@ class another_TestService(Service):
         return _raw
 
     def maybe_get_raw_data(self, auth_header: str, dataset_rid: str) -> Optional[Any]:
+        _conjure_encoder = ConjureEncoder()
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
@@ -159,8 +167,8 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
-            'datasetRid': dataset_rid,
+        _path_params: Dict[str, str] = {
+            'datasetRid': quote(str(_conjure_encoder.default(dataset_rid)), safe=''),
         }
 
         _json: Any = None
@@ -179,6 +187,7 @@ class another_TestService(Service):
         return None if _response.status_code == 204 else _decoder.decode(_response.json(), OptionalTypeWrapper[BinaryType], self._return_none_for_unknown_union_types)
 
     def upload_raw_data(self, auth_header: str, input: Any) -> None:
+        _conjure_encoder = ConjureEncoder()
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
@@ -189,7 +198,7 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
+        _path_params: Dict[str, str] = {
         }
 
         _data: Any = input
@@ -206,20 +215,54 @@ class another_TestService(Service):
 
         return
 
+    def upload_python_package(self, auth_header: str, upload_type: "product_UploadType", upload_type_header: "product_UploadType", upload_types_query: List["product_UploadType"] = None, upload_type_body: Optional["product_UploadType"] = None) -> None:
+        upload_types_query = upload_types_query if upload_types_query is not None else []
+        _conjure_encoder = ConjureEncoder()
+
+        _headers: Dict[str, Any] = {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+            'Authorization': auth_header,
+            'Upload-Type': _conjure_encoder.default(upload_type_header),
+        }
+
+        _params: Dict[str, Any] = {
+            'uploadTypesQuery': _conjure_encoder.default(upload_types_query),
+        }
+
+        _path_params: Dict[str, str] = {
+            'uploadType': quote(str(_conjure_encoder.default(upload_type)), safe=''),
+        }
+
+        _json: Any = _conjure_encoder.default(upload_type_body)
+
+        _path = '/catalog/data/python/{uploadType}'
+        _path = _path.format(**_path_params)
+
+        _response: Response = self._request(
+            'POST',
+            self._uri + _path,
+            params=_params,
+            headers=_headers,
+            json=_json)
+
+        return
+
     def get_branches(self, auth_header: str, dataset_rid: str, message: Optional[str] = None, page_size: Optional[int] = None) -> List[str]:
+        _conjure_encoder = ConjureEncoder()
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
             'Authorization': auth_header,
-            'Special-Message': message,
+            'Special-Message': _conjure_encoder.default(message),
         }
 
         _params: Dict[str, Any] = {
-            'pageSize': page_size,
+            'pageSize': _conjure_encoder.default(page_size),
         }
 
-        _path_params: Dict[str, Any] = {
-            'datasetRid': dataset_rid,
+        _path_params: Dict[str, str] = {
+            'datasetRid': quote(str(_conjure_encoder.default(dataset_rid)), safe=''),
         }
 
         _json: Any = None
@@ -240,6 +283,7 @@ class another_TestService(Service):
     def get_branches_deprecated(self, auth_header: str, dataset_rid: str) -> List[str]:
         """Gets all branches of this dataset.
         """
+        _conjure_encoder = ConjureEncoder()
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
@@ -249,8 +293,8 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
-            'datasetRid': dataset_rid,
+        _path_params: Dict[str, str] = {
+            'datasetRid': quote(str(_conjure_encoder.default(dataset_rid)), safe=''),
         }
 
         _json: Any = None
@@ -269,6 +313,7 @@ class another_TestService(Service):
         return _decoder.decode(_response.json(), List[str], self._return_none_for_unknown_union_types)
 
     def resolve_branch(self, auth_header: str, branch: str, dataset_rid: str) -> Optional[str]:
+        _conjure_encoder = ConjureEncoder()
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
@@ -278,9 +323,9 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
-            'datasetRid': dataset_rid,
-            'branch': branch,
+        _path_params: Dict[str, str] = {
+            'datasetRid': quote(str(_conjure_encoder.default(dataset_rid)), safe=''),
+            'branch': quote(str(_conjure_encoder.default(branch)), safe=''),
         }
 
         _json: Any = None
@@ -299,6 +344,7 @@ class another_TestService(Service):
         return None if _response.status_code == 204 else _decoder.decode(_response.json(), OptionalTypeWrapper[str], self._return_none_for_unknown_union_types)
 
     def test_param(self, auth_header: str, dataset_rid: str) -> Optional[str]:
+        _conjure_encoder = ConjureEncoder()
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
@@ -308,8 +354,8 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
-            'datasetRid': dataset_rid,
+        _path_params: Dict[str, str] = {
+            'datasetRid': quote(str(_conjure_encoder.default(dataset_rid)), safe=''),
         }
 
         _json: Any = None
@@ -330,6 +376,7 @@ class another_TestService(Service):
     def test_query_params(self, auth_header: str, implicit: str, nonlocal_: int, something: str, list: List[int] = None, set: List[int] = None) -> int:
         list = list if list is not None else []
         set = set if set is not None else []
+        _conjure_encoder = ConjureEncoder()
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
@@ -337,14 +384,14 @@ class another_TestService(Service):
         }
 
         _params: Dict[str, Any] = {
-            'different': something,
-            'implicit': implicit,
-            'list': list,
-            'set': set,
-            'nonlocal': nonlocal_,
+            'different': _conjure_encoder.default(something),
+            'implicit': _conjure_encoder.default(implicit),
+            'list': _conjure_encoder.default(list),
+            'set': _conjure_encoder.default(set),
+            'nonlocal': _conjure_encoder.default(nonlocal_),
         }
 
-        _path_params: Dict[str, Any] = {
+        _path_params: Dict[str, str] = {
         }
 
         _json: Any = None
@@ -363,6 +410,7 @@ class another_TestService(Service):
         return _decoder.decode(_response.json(), int, self._return_none_for_unknown_union_types)
 
     def test_boolean(self, auth_header: str) -> bool:
+        _conjure_encoder = ConjureEncoder()
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
@@ -372,7 +420,7 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
+        _path_params: Dict[str, str] = {
         }
 
         _json: Any = None
@@ -391,6 +439,7 @@ class another_TestService(Service):
         return _decoder.decode(_response.json(), bool, self._return_none_for_unknown_union_types)
 
     def test_double(self, auth_header: str) -> float:
+        _conjure_encoder = ConjureEncoder()
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
@@ -400,7 +449,7 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
+        _path_params: Dict[str, str] = {
         }
 
         _json: Any = None
@@ -419,6 +468,7 @@ class another_TestService(Service):
         return _decoder.decode(_response.json(), float, self._return_none_for_unknown_union_types)
 
     def test_integer(self, auth_header: str) -> int:
+        _conjure_encoder = ConjureEncoder()
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
@@ -428,7 +478,7 @@ class another_TestService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
+        _path_params: Dict[str, str] = {
         }
 
         _json: Any = None
@@ -455,6 +505,7 @@ another_TestService.__module__ = "package_name.another"
 class nested_deeply_nested_service_DeeplyNestedService(Service):
 
     def test_endpoint(self, string: str) -> str:
+        _conjure_encoder = ConjureEncoder()
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
@@ -464,10 +515,10 @@ class nested_deeply_nested_service_DeeplyNestedService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
+        _path_params: Dict[str, str] = {
         }
 
-        _json: Any = ConjureEncoder().default(string)
+        _json: Any = _conjure_encoder.default(string)
 
         _path = '/catalog/testEndpoint'
         _path = _path.format(**_path_params)
@@ -491,6 +542,7 @@ nested_deeply_nested_service_DeeplyNestedService.__module__ = "package_name.nest
 class nested_service2_SimpleNestedService2(Service):
 
     def test_endpoint(self, string: str) -> str:
+        _conjure_encoder = ConjureEncoder()
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
@@ -500,10 +552,10 @@ class nested_service2_SimpleNestedService2(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
+        _path_params: Dict[str, str] = {
         }
 
-        _json: Any = ConjureEncoder().default(string)
+        _json: Any = _conjure_encoder.default(string)
 
         _path = '/catalog/testEndpoint'
         _path = _path.format(**_path_params)
@@ -527,6 +579,7 @@ nested_service2_SimpleNestedService2.__module__ = "package_name.nested_service2"
 class nested_service_SimpleNestedService(Service):
 
     def test_endpoint(self, string: str) -> str:
+        _conjure_encoder = ConjureEncoder()
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
@@ -536,10 +589,10 @@ class nested_service_SimpleNestedService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
+        _path_params: Dict[str, str] = {
         }
 
-        _json: Any = ConjureEncoder().default(string)
+        _json: Any = _conjure_encoder.default(string)
 
         _path = '/catalog/testEndpoint'
         _path = _path.format(**_path_params)
@@ -1691,6 +1744,24 @@ product_UnionWithBuiltinVariantNameVisitor.__qualname__ = "UnionWithBuiltinVaria
 product_UnionWithBuiltinVariantNameVisitor.__module__ = "package_name.product"
 
 
+class product_UploadType(ConjureEnumType):
+
+    PYPI = 'PYPI'
+    '''PYPI'''
+    CONDA = 'CONDA'
+    '''CONDA'''
+    UNKNOWN = 'UNKNOWN'
+    '''UNKNOWN'''
+
+    def __reduce_ex__(self, proto):
+        return self.__class__, (self.name,)
+
+
+product_UploadType.__name__ = "UploadType"
+product_UploadType.__qualname__ = "UploadType"
+product_UploadType.__module__ = "package_name.product"
+
+
 class product_UuidExample(ConjureBeanType):
 
     @builtins.classmethod
@@ -1814,6 +1885,7 @@ with_imports_ComplexObjectWithImports.__module__ = "package_name.with_imports"
 class with_imports_ImportService(Service):
 
     def test_endpoint(self, imported_string: "product_StringExample") -> "product_datasets_BackingFileSystem":
+        _conjure_encoder = ConjureEncoder()
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
@@ -1823,10 +1895,10 @@ class with_imports_ImportService(Service):
         _params: Dict[str, Any] = {
         }
 
-        _path_params: Dict[str, Any] = {
+        _path_params: Dict[str, str] = {
         }
 
-        _json: Any = ConjureEncoder().default(imported_string)
+        _json: Any = _conjure_encoder.default(imported_string)
 
         _path = '/catalog/testEndpoint'
         _path = _path.format(**_path_params)

--- a/conjure-python-core/src/test/resources/types/expected/package_name/product/__init__.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/product/__init__.py
@@ -46,6 +46,7 @@ from .._impl import (
     product_UnionTypeExampleVisitor as UnionTypeExampleVisitor,
     product_UnionWithBuiltinVariantName as UnionWithBuiltinVariantName,
     product_UnionWithBuiltinVariantNameVisitor as UnionWithBuiltinVariantNameVisitor,
+    product_UploadType as UploadType,
     product_UuidAliasExample as UuidAliasExample,
     product_UuidExample as UuidExample,
 )
@@ -97,6 +98,7 @@ __all__ = [
     'UnionTypeExampleVisitor',
     'UnionWithBuiltinVariantName',
     'UnionWithBuiltinVariantNameVisitor',
+    'UploadType',
     'UuidAliasExample',
     'UuidExample',
 ]


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
This PR address two things:
- Enums are not properly handled in path params, query params, and headers as they are just taken as the string representation of the enum object which ends up being like `UploadType.CONDA` instead of `CONDA` for an enum named `UploadType`. So this PR encodes path params, query params and additional user headers, which should only change behavior for (maybe nested) enums in these variables.
- Path params are not url encoded so users passing strings such as "my/value" will mess with the url of the request since the "/" is not escaped, so now encoding path params via `urllib.parse.quote` which will handle this
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

