### PR TITLE
Fix: Missing `Bearer` in header authorization

### DIFF
--- a/changelog/@unreleased/pr-981.v2.yml
+++ b/changelog/@unreleased/pr-981.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Missing `Bearer` in header authorization
+  links:
+  - https://github.com/palantir/conjure-python/pull/981

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java
@@ -145,7 +145,7 @@ public interface PythonEndpointDefinition extends Emittable {
                                 .getParamId()
                                 .get();
                         if (param.pythonParamName().equals(AUTH_HEADER_PYTHON_PARAM_NAME)) {
-                            poetWriter.writeIndentedLine("'%s': %s,", headerParamId, param.pythonParamName());
+                            poetWriter.writeIndentedLine("'%s': Bearer %s,", headerParamId, param.pythonParamName());
                         } else {
                             poetWriter.writeIndentedLine(
                                     "'%s': _conjure_encoder.default(%s),", headerParamId, param.pythonParamName());

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java
@@ -148,11 +148,10 @@ public interface PythonEndpointDefinition extends Emittable {
                                 .get();
                         if (param.pythonParamName().equals(AUTH_HEADER_PYTHON_PARAM_NAME)) {
                             poetWriter.writeIndentedLine(
-                                    "'%s': %s if %s.startswith('%s') else f'%s{%s}',",
+                                    "'%s': %s if %s.lower().startswith('bearer ') else f'%s{%s}',",
                                     headerParamId,
                                     param.pythonParamName(),
                                     param.pythonParamName(),
-                                    AUTH_HEADER_BEARER_PREFIX,
                                     AUTH_HEADER_BEARER_PREFIX,
                                     param.pythonParamName());
                         } else {

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java
@@ -145,7 +145,8 @@ public interface PythonEndpointDefinition extends Emittable {
                                 .getParamId()
                                 .get();
                         if (param.pythonParamName().equals(AUTH_HEADER_PYTHON_PARAM_NAME)) {
-                            poetWriter.writeIndentedLine("'%s': f'Bearer {%s}',", headerParamId, param.pythonParamName());
+                            poetWriter.writeIndentedLine(
+                                    "'%s': f'Bearer {%s}',", headerParamId, param.pythonParamName());
                         } else {
                             poetWriter.writeIndentedLine(
                                     "'%s': _conjure_encoder.default(%s),", headerParamId, param.pythonParamName());

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java
@@ -145,7 +145,7 @@ public interface PythonEndpointDefinition extends Emittable {
                                 .getParamId()
                                 .get();
                         if (param.pythonParamName().equals(AUTH_HEADER_PYTHON_PARAM_NAME)) {
-                            poetWriter.writeIndentedLine("'%s': Bearer %s,", headerParamId, param.pythonParamName());
+                            poetWriter.writeIndentedLine("'%s': f'Bearer {%s}',", headerParamId, param.pythonParamName());
                         } else {
                             poetWriter.writeIndentedLine(
                                     "'%s': _conjure_encoder.default(%s),", headerParamId, param.pythonParamName());

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java
@@ -40,6 +40,8 @@ import org.immutables.value.Value;
 public interface PythonEndpointDefinition extends Emittable {
     String AUTH_HEADER_PYTHON_PARAM_NAME = "auth_header";
 
+    String AUTH_HEADER_BEARER_PREFIX = "Bearer ";
+
     String pythonMethodName();
 
     HttpMethod httpMethod();
@@ -146,7 +148,13 @@ public interface PythonEndpointDefinition extends Emittable {
                                 .get();
                         if (param.pythonParamName().equals(AUTH_HEADER_PYTHON_PARAM_NAME)) {
                             poetWriter.writeIndentedLine(
-                                    "'%s': f'Bearer {%s}',", headerParamId, param.pythonParamName());
+                                    "'%s': %s if %s.startswith('%s') else f'%s{%s}',",
+                                    headerParamId,
+                                    param.pythonParamName(),
+                                    param.pythonParamName(),
+                                    AUTH_HEADER_BEARER_PREFIX,
+                                    AUTH_HEADER_BEARER_PREFIX,
+                                    param.pythonParamName());
                         } else {
                             poetWriter.writeIndentedLine(
                                     "'%s': _conjure_encoder.default(%s),", headerParamId, param.pythonParamName());

--- a/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
@@ -44,7 +44,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -74,7 +74,7 @@ class another_TestService(Service):
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
             'Content-Type': 'application/json',
-            'Authorization': f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
             'Test-Header': _conjure_encoder.default(test_header_arg),
         }
 
@@ -104,7 +104,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -134,7 +134,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/octet-stream',
-            'Authorization': f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -166,7 +166,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -197,7 +197,7 @@ class another_TestService(Service):
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
             'Content-Type': 'application/octet-stream',
-            'Authorization': f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -227,7 +227,7 @@ class another_TestService(Service):
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
             'Content-Type': 'application/json',
-            'Authorization': f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
             'Upload-Type': _conjure_encoder.default(upload_type_header),
         }
 
@@ -258,7 +258,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
             'Special-Message': _conjure_encoder.default(message),
         }
 
@@ -292,7 +292,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -322,7 +322,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -353,7 +353,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -385,7 +385,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -419,7 +419,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -448,7 +448,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -477,7 +477,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {

--- a/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
@@ -44,7 +44,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.lower().startswith('bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -74,7 +74,7 @@ class another_TestService(Service):
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
             'Content-Type': 'application/json',
-            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.lower().startswith('bearer ') else f'Bearer {auth_header}',
             'Test-Header': _conjure_encoder.default(test_header_arg),
         }
 
@@ -104,7 +104,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.lower().startswith('bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -134,7 +134,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/octet-stream',
-            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.lower().startswith('bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -166,7 +166,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.lower().startswith('bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -197,7 +197,7 @@ class another_TestService(Service):
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
             'Content-Type': 'application/octet-stream',
-            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.lower().startswith('bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -227,7 +227,7 @@ class another_TestService(Service):
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
             'Content-Type': 'application/json',
-            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.lower().startswith('bearer ') else f'Bearer {auth_header}',
             'Upload-Type': _conjure_encoder.default(upload_type_header),
         }
 
@@ -258,7 +258,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.lower().startswith('bearer ') else f'Bearer {auth_header}',
             'Special-Message': _conjure_encoder.default(message),
         }
 
@@ -292,7 +292,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.lower().startswith('bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -322,7 +322,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.lower().startswith('bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -353,7 +353,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.lower().startswith('bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -385,7 +385,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.lower().startswith('bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -419,7 +419,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.lower().startswith('bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -448,7 +448,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.lower().startswith('bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -477,7 +477,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.lower().startswith('bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {

--- a/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
@@ -44,7 +44,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header,
+            'Authorization': f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -74,7 +74,7 @@ class another_TestService(Service):
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
             'Content-Type': 'application/json',
-            'Authorization': auth_header,
+            'Authorization': f'Bearer {auth_header}',,
             'Test-Header': _conjure_encoder.default(test_header_arg),
         }
 
@@ -104,7 +104,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header,
+            'Authorization': f'Bearer {auth_header}',,
         }
 
         _params: Dict[str, Any] = {
@@ -134,7 +134,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/octet-stream',
-            'Authorization': auth_header,
+            'Authorization': f'Bearer {auth_header}',,
         }
 
         _params: Dict[str, Any] = {
@@ -166,7 +166,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header,
+            'Authorization': f'Bearer {auth_header}',,
         }
 
         _params: Dict[str, Any] = {
@@ -197,7 +197,7 @@ class another_TestService(Service):
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
             'Content-Type': 'application/octet-stream',
-            'Authorization': auth_header,
+            'Authorization': f'Bearer {auth_header}',,
         }
 
         _params: Dict[str, Any] = {
@@ -227,7 +227,7 @@ class another_TestService(Service):
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
             'Content-Type': 'application/json',
-            'Authorization': auth_header,
+            'Authorization': f'Bearer {auth_header}',,
             'Upload-Type': _conjure_encoder.default(upload_type_header),
         }
 
@@ -258,7 +258,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header,
+            'Authorization': f'Bearer {auth_header}',,
             'Special-Message': _conjure_encoder.default(message),
         }
 
@@ -292,7 +292,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header,
+            'Authorization': f'Bearer {auth_header}',,
         }
 
         _params: Dict[str, Any] = {
@@ -322,7 +322,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header,
+            'Authorization': f'Bearer {auth_header}',,
         }
 
         _params: Dict[str, Any] = {
@@ -353,7 +353,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header,
+            'Authorization': f'Bearer {auth_header}',,
         }
 
         _params: Dict[str, Any] = {
@@ -385,7 +385,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header,
+            'Authorization': f'Bearer {auth_header}',,
         }
 
         _params: Dict[str, Any] = {
@@ -419,7 +419,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header,
+            'Authorization': f'Bearer {auth_header}',,
         }
 
         _params: Dict[str, Any] = {
@@ -448,7 +448,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header,
+            'Authorization': f'Bearer {auth_header}',,
         }
 
         _params: Dict[str, Any] = {
@@ -477,7 +477,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header,
+            'Authorization': f'Bearer {auth_header}',,
         }
 
         _params: Dict[str, Any] = {

--- a/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/services/expected/package_name/_impl.py
@@ -74,7 +74,7 @@ class another_TestService(Service):
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
             'Content-Type': 'application/json',
-            'Authorization': f'Bearer {auth_header}',,
+            'Authorization': f'Bearer {auth_header}',
             'Test-Header': _conjure_encoder.default(test_header_arg),
         }
 
@@ -104,7 +104,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': f'Bearer {auth_header}',,
+            'Authorization': f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -134,7 +134,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/octet-stream',
-            'Authorization': f'Bearer {auth_header}',,
+            'Authorization': f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -166,7 +166,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': f'Bearer {auth_header}',,
+            'Authorization': f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -197,7 +197,7 @@ class another_TestService(Service):
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
             'Content-Type': 'application/octet-stream',
-            'Authorization': f'Bearer {auth_header}',,
+            'Authorization': f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -227,7 +227,7 @@ class another_TestService(Service):
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
             'Content-Type': 'application/json',
-            'Authorization': f'Bearer {auth_header}',,
+            'Authorization': f'Bearer {auth_header}',
             'Upload-Type': _conjure_encoder.default(upload_type_header),
         }
 
@@ -258,7 +258,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': f'Bearer {auth_header}',,
+            'Authorization': f'Bearer {auth_header}',
             'Special-Message': _conjure_encoder.default(message),
         }
 
@@ -292,7 +292,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': f'Bearer {auth_header}',,
+            'Authorization': f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -322,7 +322,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': f'Bearer {auth_header}',,
+            'Authorization': f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -353,7 +353,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': f'Bearer {auth_header}',,
+            'Authorization': f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -385,7 +385,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': f'Bearer {auth_header}',,
+            'Authorization': f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -419,7 +419,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': f'Bearer {auth_header}',,
+            'Authorization': f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -448,7 +448,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': f'Bearer {auth_header}',,
+            'Authorization': f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -477,7 +477,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': f'Bearer {auth_header}',,
+            'Authorization': f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {

--- a/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
@@ -48,7 +48,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -78,7 +78,7 @@ class another_TestService(Service):
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
             'Content-Type': 'application/json',
-            'Authorization': f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
             'Test-Header': _conjure_encoder.default(test_header_arg),
         }
 
@@ -108,7 +108,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -138,7 +138,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/octet-stream',
-            'Authorization': f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -170,7 +170,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -201,7 +201,7 @@ class another_TestService(Service):
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
             'Content-Type': 'application/octet-stream',
-            'Authorization': f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -231,7 +231,7 @@ class another_TestService(Service):
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
             'Content-Type': 'application/json',
-            'Authorization': f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
             'Upload-Type': _conjure_encoder.default(upload_type_header),
         }
 
@@ -262,7 +262,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
             'Special-Message': _conjure_encoder.default(message),
         }
 
@@ -296,7 +296,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -326,7 +326,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -357,7 +357,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -389,7 +389,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -423,7 +423,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -452,7 +452,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -481,7 +481,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {

--- a/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
@@ -48,7 +48,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.lower().startswith('bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -78,7 +78,7 @@ class another_TestService(Service):
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
             'Content-Type': 'application/json',
-            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.lower().startswith('bearer ') else f'Bearer {auth_header}',
             'Test-Header': _conjure_encoder.default(test_header_arg),
         }
 
@@ -108,7 +108,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.lower().startswith('bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -138,7 +138,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/octet-stream',
-            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.lower().startswith('bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -170,7 +170,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.lower().startswith('bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -201,7 +201,7 @@ class another_TestService(Service):
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
             'Content-Type': 'application/octet-stream',
-            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.lower().startswith('bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -231,7 +231,7 @@ class another_TestService(Service):
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
             'Content-Type': 'application/json',
-            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.lower().startswith('bearer ') else f'Bearer {auth_header}',
             'Upload-Type': _conjure_encoder.default(upload_type_header),
         }
 
@@ -262,7 +262,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.lower().startswith('bearer ') else f'Bearer {auth_header}',
             'Special-Message': _conjure_encoder.default(message),
         }
 
@@ -296,7 +296,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.lower().startswith('bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -326,7 +326,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.lower().startswith('bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -357,7 +357,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.lower().startswith('bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -389,7 +389,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.lower().startswith('bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -423,7 +423,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.lower().startswith('bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -452,7 +452,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.lower().startswith('bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -481,7 +481,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header if auth_header.startswith('Bearer ') else f'Bearer {auth_header}',
+            'Authorization': auth_header if auth_header.lower().startswith('bearer ') else f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {

--- a/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/types/expected/package_name/_impl.py
@@ -48,7 +48,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header,
+            'Authorization': f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -78,7 +78,7 @@ class another_TestService(Service):
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
             'Content-Type': 'application/json',
-            'Authorization': auth_header,
+            'Authorization': f'Bearer {auth_header}',
             'Test-Header': _conjure_encoder.default(test_header_arg),
         }
 
@@ -108,7 +108,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header,
+            'Authorization': f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -138,7 +138,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/octet-stream',
-            'Authorization': auth_header,
+            'Authorization': f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -170,7 +170,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header,
+            'Authorization': f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -201,7 +201,7 @@ class another_TestService(Service):
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
             'Content-Type': 'application/octet-stream',
-            'Authorization': auth_header,
+            'Authorization': f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -231,7 +231,7 @@ class another_TestService(Service):
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
             'Content-Type': 'application/json',
-            'Authorization': auth_header,
+            'Authorization': f'Bearer {auth_header}',
             'Upload-Type': _conjure_encoder.default(upload_type_header),
         }
 
@@ -262,7 +262,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header,
+            'Authorization': f'Bearer {auth_header}',
             'Special-Message': _conjure_encoder.default(message),
         }
 
@@ -296,7 +296,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header,
+            'Authorization': f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -326,7 +326,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header,
+            'Authorization': f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -357,7 +357,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header,
+            'Authorization': f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -389,7 +389,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header,
+            'Authorization': f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -423,7 +423,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header,
+            'Authorization': f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -452,7 +452,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header,
+            'Authorization': f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {
@@ -481,7 +481,7 @@ class another_TestService(Service):
 
         _headers: Dict[str, Any] = {
             'Accept': 'application/json',
-            'Authorization': auth_header,
+            'Authorization': f'Bearer {auth_header}',
         }
 
         _params: Dict[str, Any] = {


### PR DESCRIPTION
## Before this PR

According to the [wire spec](https://github.com/palantir/conjure/blob/master/docs/spec/wire.md#244-header-authorization), `Bearer` shall be part of the generated auth header, but it's not the case based on the current implementation.

## After this PR

Patching it up. Am I supposed to edit `expected/_impl.py` directly? It says it's a generated file though I can't find the sources.

==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

This change is potentially breaking (e.g. `Bearer` might be manually prepended at the callsites), so happy to just discuss and put it on the radar https://github.com/palantir/conjure-python/issues/982.

