### PR TITLE
Add `self` to python keywords

### DIFF
--- a/changelog/@unreleased/pr-984.v2.yml
+++ b/changelog/@unreleased/pr-984.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Add `self` to python keywords
+  links:
+  - https://github.com/palantir/conjure-python/pull/984

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/processors/PythonIdentifierSanitizer.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/processors/PythonIdentifierSanitizer.java
@@ -57,6 +57,7 @@ public final class PythonIdentifierSanitizer {
             "print",
             "raise",
             "return",
+            "self",
             "str",
             "try",
             "while",


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
The code generator creates an `__init__()` method for the conjure bean type, which includes `self` along every class field. If a field is called `self`, python throws a `SyntaxError: duplicate argument 'self' in function definition`

Adding `self` to the python keywords so the generator adds an underscore suffix in that case

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
This is technically a breaking change (as the class needs to be called with `MyClass(self_=value)` instead of `MyClass(self=value)` - but in practice, this would never have happened as the previous code would have thrown a SyntaxError.
