### PR TITLE
Bump conjure-python-client upper bound to <4

### DIFF
--- a/changelog/@unreleased/pr-1036.v2.yml
+++ b/changelog/@unreleased/pr-1036.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Bump conjure-python-client upper bound to <4
+  links:
+  - https://github.com/palantir/conjure-python/pull/1036

--- a/conjure-python-core/src/test/java/com/palantir/conjure/python/ConjurePythonGeneratorTest.java
+++ b/conjure-python-core/src/test/java/com/palantir/conjure/python/ConjurePythonGeneratorTest.java
@@ -40,6 +40,7 @@ public final class ConjurePythonGeneratorTest {
             .packageVersion("0.0.0")
             .packageDescription("project description")
             .minConjureClientVersion("2.8.0")
+            .maxConjureClientVersion("4")
             .generatorVersion("0.0.0")
             .shouldWriteCondaRecipe(true)
             .generateRawSource(false)
@@ -60,7 +61,7 @@ public final class ConjurePythonGeneratorTest {
         Set<Path> generatedButNotExpected = pythonFileWriter.getPythonFiles().keySet();
         long count = 0;
         try (Stream<Path> walk = Files.walk(expected)) {
-            for (Path path : walk.collect(Collectors.toList())) {
+            for (Path path : walk.toList()) {
                 if (!path.toFile().isFile()) {
                     continue;
                 }
@@ -76,7 +77,7 @@ public final class ConjurePythonGeneratorTest {
     }
 
     private void maybeResetExpectedDirectory(Path expected, ConjureDefinition definition) throws IOException {
-        if (Boolean.valueOf(System.getProperty("recreate", "false"))
+        if (Boolean.parseBoolean(System.getProperty("recreate", "false"))
                 || !expected.toFile().isDirectory()) {
             Files.createDirectories(expected);
             try (Stream<Path> walk = Files.walk(expected)) {

--- a/conjure-python-core/src/test/resources/services/expected/conda_recipe/meta.yaml
+++ b/conjure-python-core/src/test/resources/services/expected/conda_recipe/meta.yaml
@@ -15,9 +15,9 @@ requirements:
         - python
         - setuptools
         - requests
-        - conjure-python-client >=2.8.0,<3
+        - conjure-python-client >=2.8.0,<4
 
     run:
         - python
         - requests
-        - conjure-python-client >=2.8.0,<3
+        - conjure-python-client >=2.8.0,<4

--- a/conjure-python-core/src/test/resources/services/expected/setup.py
+++ b/conjure-python-core/src/test/resources/services/expected/setup.py
@@ -13,6 +13,6 @@ setup(
     packages=find_packages(),
     install_requires=[
         'requests',
-        'conjure-python-client>=2.8.0,<3',
+        'conjure-python-client>=2.8.0,<4',
     ],
 )

--- a/conjure-python-core/src/test/resources/types/expected/conda_recipe/meta.yaml
+++ b/conjure-python-core/src/test/resources/types/expected/conda_recipe/meta.yaml
@@ -15,9 +15,9 @@ requirements:
         - python
         - setuptools
         - requests
-        - conjure-python-client >=2.8.0,<3
+        - conjure-python-client >=2.8.0,<4
 
     run:
         - python
         - requests
-        - conjure-python-client >=2.8.0,<3
+        - conjure-python-client >=2.8.0,<4

--- a/conjure-python-core/src/test/resources/types/expected/setup.py
+++ b/conjure-python-core/src/test/resources/types/expected/setup.py
@@ -13,6 +13,6 @@ setup(
     packages=find_packages(),
     install_requires=[
         'requests',
-        'conjure-python-client>=2.8.0,<3',
+        'conjure-python-client>=2.8.0,<4',
     ],
 )

--- a/conjure-python/build.gradle
+++ b/conjure-python/build.gradle
@@ -42,10 +42,12 @@ dependencies {
 task generateBuildConfiguration {
     doLast {
         def minConjureClientVersion = conjurePythonClientVersion
+        def maxConjureClientVersion = maxConjurePythonClientVersion
         def props = new File("$projectDir/src/main/resources/buildConfiguration.yml")
         props.getParentFile().mkdirs()
         props.text = "generatorVersion: ${project.version}\n"
         props.text += "minConjureClientVersion: $minConjureClientVersion\n"
+        props.text += "maxConjureClientVersion: $maxConjureClientVersion\n"
     }
 }
 

--- a/conjure-python/src/main/java/com/palantir/conjure/python/cli/BuildConfiguration.java
+++ b/conjure-python/src/main/java/com/palantir/conjure/python/cli/BuildConfiguration.java
@@ -34,6 +34,8 @@ public abstract class BuildConfiguration {
 
     abstract String minConjureClientVersion();
 
+    abstract String maxConjureClientVersion();
+
     static BuildConfiguration load() {
         try {
             return OBJECT_MAPPER.readValue(

--- a/conjure-python/src/main/java/com/palantir/conjure/python/cli/ConjurePythonCli.java
+++ b/conjure-python/src/main/java/com/palantir/conjure/python/cli/ConjurePythonCli.java
@@ -126,6 +126,7 @@ public final class ConjurePythonCli implements Runnable {
             return GeneratorConfiguration.builder()
                     .generatorVersion(buildConfig.generatorVersion())
                     .minConjureClientVersion(buildConfig.minConjureClientVersion())
+                    .maxConjureClientVersion(buildConfig.maxConjureClientVersion())
                     .packageAuthor(cliConfig.packageAuthor())
                     .packageDescription(cliConfig.packageDescription())
                     .packageName(cliConfig.packageName())

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
 org.gradle.parallel=true
 conjurePythonClientVersion=2.8.0
+maxConjurePythonClientVersion=4
 org.gradle.jvmargs = --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 palantir.jdk.setup.enabled=true
 palantir.native.formatter=true


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
conjure-python-client 3.0.0 was released, dropping 3.8 support, but no other semantic changes. So bump the upper bound for conjure python to <4 such that this version, and any subsequent 3.x.x changes can be used. 3.x.x will not include any breaking changes to respect semver and avoid this change from breaking consumers.

Closes https://github.com/palantir/conjure-python/issues/1027
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

