### PR TITLE
Support optionals in union types

### DIFF
--- a/changelog/@unreleased/pr-1050.v2.yml
+++ b/changelog/@unreleased/pr-1050.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Support optionals in union types
+  links:
+  - https://github.com/palantir/conjure-python/pull/1050

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
@@ -200,7 +200,7 @@ public interface UnionSnippet extends PythonSnippet {
                     "raise ValueError('{} is not an instance of %s'.format(visitor.__class__.__name__))", visitorName);
             poetWriter.decreaseIndent();
             options().forEach(option -> {
-                if (parameterName(option).equals("optional")) {
+                if (!option.isOptional()) {
                     poetWriter.writeIndentedLine("if self._type == '%s':", parameterName(option));
                 } else {
                     poetWriter.writeIndentedLine(

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
@@ -163,7 +163,7 @@ public interface UnionSnippet extends PythonSnippet {
                 poetWriter.writeIndentedLine("elif type_of_union == '%s':", option.jsonIdentifier());
                 poetWriter.increaseIndent();
 
-                if (!parameterName(option).equals("optional")) {
+                if (!option.isOptional()) {
                     poetWriter.writeIndentedLine("if %s is None:", parameterName(option));
                     poetWriter.increaseIndent();
                     poetWriter.writeIndentedLine("raise ValueError('a union value must not be None')");

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
@@ -200,7 +200,7 @@ public interface UnionSnippet extends PythonSnippet {
                     "raise ValueError('{} is not an instance of %s'.format(visitor.__class__.__name__))", visitorName);
             poetWriter.decreaseIndent();
             options().forEach(option -> {
-                if (!option.isOptional()) {
+                if (option.isOptional()) {
                     poetWriter.writeIndentedLine("if self._type == '%s':", parameterName(option));
                 } else {
                     poetWriter.writeIndentedLine(


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
When deserializing a union type, we generally throw an error if the field corresponding to the `type_of_union` is set to `None`. The only exception was when the field was literally called `"optional"` - instead, we should validate whether the FieldType is optional. This allows us to now handle arbitrary unions, e.g.:
```
MyUnionType:
  union:
    maybeValue1: optional<Value1>
    maybeValue2: optional<Value2>
```

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

