### PR TITLE
Feature: Add an option to generate keyword-only arguments

### DIFF
--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/ConjurePythonGenerator.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/ConjurePythonGenerator.java
@@ -139,13 +139,15 @@ public final class ConjurePythonGenerator {
                 implTypeNameProcessor,
                 definitionPackageNameProcessor,
                 definitionTypeNameProcessor,
-                dealiasingTypeVisitor);
+                dealiasingTypeVisitor,
+                config.forceKeywordArgs());
         ClientGenerator clientGenerator = new ClientGenerator(
                 implPackageNameProcessor,
                 implTypeNameProcessor,
                 definitionPackageNameProcessor,
                 definitionTypeNameProcessor,
-                dealiasingTypeVisitor);
+                dealiasingTypeVisitor,
+                config.forceKeywordArgs());
 
         List<PythonSnippet> snippets = new ArrayList<>();
         snippets.addAll(conjureDefinition.getTypes().stream()

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/GeneratorConfiguration.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/GeneratorConfiguration.java
@@ -43,6 +43,11 @@ public interface GeneratorConfiguration {
 
     boolean generateRawSource();
 
+    @Value.Default
+    default boolean forceKeywordArgs() {
+        return false;
+    }
+
     default Optional<String> pythonicPackageName() {
         return packageName().map(packageName -> packageName.replace('-', '_'));
     }

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/client/ClientGenerator.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/client/ClientGenerator.java
@@ -48,18 +48,21 @@ public final class ClientGenerator {
     private final DealiasingTypeVisitor dealiasingTypeVisitor;
     private final PythonTypeNameVisitor pythonTypeNameVisitor;
     private final MyPyTypeNameVisitor myPyTypeNameVisitor;
+    private final boolean forceKeywordArgs;
 
     public ClientGenerator(
             PackageNameProcessor implPackageNameProcessor,
             TypeNameProcessor implTypeNameProcessor,
             PackageNameProcessor definitionPackageNameProcessor,
             TypeNameProcessor definitionTypeNameProcessor,
-            DealiasingTypeVisitor dealiasingTypeVisitor) {
+            DealiasingTypeVisitor dealiasingTypeVisitor,
+            boolean forceKeywordArgs) {
         this.implPackageNameProcessor = implPackageNameProcessor;
         this.implTypeNameProcessor = implTypeNameProcessor;
         this.definitionPackageNameProcessor = definitionPackageNameProcessor;
         this.definitionTypeNameProcessor = definitionTypeNameProcessor;
         this.dealiasingTypeVisitor = dealiasingTypeVisitor;
+        this.forceKeywordArgs = forceKeywordArgs;
         pythonTypeNameVisitor = new PythonTypeNameVisitor(implTypeNameProcessor);
         myPyTypeNameVisitor = new MyPyTypeNameVisitor(dealiasingTypeVisitor, implTypeNameProcessor);
     }
@@ -154,6 +157,7 @@ public final class ClientGenerator {
                                 .dealias(rt)
                                 .fold(_typeDefinition -> false, type -> type.accept(TypeVisitor.IS_OPTIONAL)))
                         .orElse(false))
+                .forceKeywordArgs(forceKeywordArgs)
                 .build();
     }
 }

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/BeanSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/BeanSnippet.java
@@ -57,6 +57,11 @@ public interface BeanSnippet extends PythonSnippet {
 
     List<PythonField> fields();
 
+    @Value.Default
+    default boolean forceKeywordArgs() {
+        return false;
+    }
+
     @Override
     default void emit(PythonPoetWriter poetWriter) {
         poetWriter.writeIndentedLine(String.format("class %s(ConjureBeanType):", className()));
@@ -97,22 +102,25 @@ public interface BeanSnippet extends PythonSnippet {
 
         // constructor -- only if there are fields
         if (!fields().isEmpty()) {
-            poetWriter.writeIndentedLine(String.format(
-                    "def __init__(self, %s) -> None:",
-                    Joiner.on(", ")
-                            .join(fields().stream()
-                                    .sorted(new PythonField.PythonFieldComparator())
-                                    .map(field -> {
-                                        String name = String.format(
-                                                "%s: %s",
-                                                PythonIdentifierSanitizer.sanitize(field.attributeName()),
-                                                field.myPyType());
-                                        if (field.isOptional()) {
-                                            return String.format("%s = None", name);
-                                        }
-                                        return name;
-                                    })
-                                    .collect(Collectors.toList()))));
+            String argsString = Joiner.on(", ")
+                    .join(fields().stream()
+                            .sorted(new PythonField.PythonFieldComparator())
+                            .map(field -> {
+                                String name = String.format(
+                                        "%s: %s",
+                                        PythonIdentifierSanitizer.sanitize(field.attributeName()), field.myPyType());
+                                if (field.isOptional()) {
+                                    return String.format("%s = None", name);
+                                }
+                                return name;
+                            })
+                            .collect(Collectors.toList()));
+
+            String initSignature = forceKeywordArgs()
+                    ? String.format("def __init__(self, *, %s) -> None:", argsString)
+                    : String.format("def __init__(self, %s) -> None:", argsString);
+
+            poetWriter.writeIndentedLine(initSignature);
             poetWriter.increaseIndent();
             fields().forEach(field -> poetWriter.writeIndentedLine(String.format(
                     "self._%s = %s",

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java
@@ -62,6 +62,11 @@ public interface PythonEndpointDefinition extends Emittable {
 
     Optional<String> myPyReturnType();
 
+    @Value.Default
+    default boolean forceKeywordArgs() {
+        return false;
+    }
+
     @Value.Check
     default void check() {
         checkState(
@@ -90,22 +95,27 @@ public interface PythonEndpointDefinition extends Emittable {
                             .build()
                     : params();
 
-            poetWriter.writeIndentedLine(
-                    "def %s(self, %s) -> %s:",
-                    pythonMethodName(),
-                    Joiner.on(", ")
-                            .join(paramsWithHeader.stream()
-                                    .sorted(new PythonEndpointParamComparator())
-                                    .map(param -> {
-                                        String typedParam =
-                                                String.format("%s: %s", param.pythonParamName(), param.myPyType());
-                                        if (param.isOptional() || param.isCollection()) {
-                                            return String.format("%s = None", typedParam);
-                                        }
-                                        return typedParam;
-                                    })
-                                    .collect(Collectors.toList())),
-                    myPyReturnType().orElse("None"));
+            String paramsString = Joiner.on(", ")
+                    .join(paramsWithHeader.stream()
+                            .sorted(new PythonEndpointParamComparator())
+                            .map(param -> {
+                                String typedParam = String.format("%s: %s", param.pythonParamName(), param.myPyType());
+                                if (param.isOptional() || param.isCollection()) {
+                                    return String.format("%s = None", typedParam);
+                                }
+                                return typedParam;
+                            })
+                            .collect(Collectors.toList()));
+
+            String methodSignature = forceKeywordArgs() && !paramsWithHeader.isEmpty()
+                    ? String.format(
+                            "def %s(self, *, %s) -> %s:",
+                            pythonMethodName(), paramsString, myPyReturnType().orElse("None"))
+                    : String.format(
+                            "def %s(self, %s) -> %s:",
+                            pythonMethodName(), paramsString, myPyReturnType().orElse("None"));
+
+            poetWriter.writeIndentedLine(methodSignature);
             poetWriter.increaseIndent();
             docs().ifPresent(poetWriter::writeDocs);
 

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/UnionSnippet.java
@@ -61,6 +61,11 @@ public interface UnionSnippet extends PythonSnippet {
 
     List<PythonField> options();
 
+    @Value.Default
+    default boolean forceKeywordArgs() {
+        return false;
+    }
+
     /** The name of the option as a constructor / method parameter. */
     static String parameterName(PythonField option) {
         return PythonIdentifierSanitizer.sanitize(option.attributeName());
@@ -120,6 +125,9 @@ public interface UnionSnippet extends PythonSnippet {
             poetWriter.increaseIndent();
             poetWriter.increaseIndent();
             poetWriter.writeIndentedLine("self,");
+            if (forceKeywordArgs() && !options().isEmpty()) {
+                poetWriter.writeIndentedLine("*,");
+            }
             for (int i = 0; i < options().size(); i++) {
                 PythonField option = options().get(i);
 

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/types/PythonTypeGenerator.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/types/PythonTypeGenerator.java
@@ -50,18 +50,21 @@ public final class PythonTypeGenerator {
     private final DealiasingTypeVisitor dealiasingTypeVisitor;
     private final PythonTypeNameVisitor pythonTypeNameVisitor;
     private final MyPyTypeNameVisitor myPyTypeNameVisitor;
+    private final boolean forceKeywordArgs;
 
     public PythonTypeGenerator(
             PackageNameProcessor implPackageNameProcessor,
             TypeNameProcessor implTypeNameProcessor,
             PackageNameProcessor definitionPackageNameProcessor,
             TypeNameProcessor definitionTypeNameProcessor,
-            DealiasingTypeVisitor dealiasingTypeVisitor) {
+            DealiasingTypeVisitor dealiasingTypeVisitor,
+            boolean forceKeywordArgs) {
         this.implPackageNameProcessor = implPackageNameProcessor;
         this.implTypeNameProcessor = implTypeNameProcessor;
         this.definitionPackageNameProcessor = definitionPackageNameProcessor;
         this.definitionTypeNameProcessor = definitionTypeNameProcessor;
         this.dealiasingTypeVisitor = dealiasingTypeVisitor;
+        this.forceKeywordArgs = forceKeywordArgs;
         pythonTypeNameVisitor = new PythonTypeNameVisitor(implTypeNameProcessor);
         myPyTypeNameVisitor = new MyPyTypeNameVisitor(dealiasingTypeVisitor, implTypeNameProcessor);
     }
@@ -127,6 +130,7 @@ public final class PythonTypeGenerator {
                 .addAllImports(imports)
                 .docs(typeDef.getDocs())
                 .fields(fields)
+                .forceKeywordArgs(forceKeywordArgs)
                 .build();
     }
 
@@ -182,6 +186,7 @@ public final class PythonTypeGenerator {
                 .addAllImports(imports)
                 .docs(typeDef.getDocs())
                 .options(options)
+                .forceKeywordArgs(forceKeywordArgs)
                 .build();
     }
 

--- a/conjure-python-core/src/test/java/com/palantir/conjure/python/ForceKeywordArgsTest.java
+++ b/conjure-python-core/src/test/java/com/palantir/conjure/python/ForceKeywordArgsTest.java
@@ -1,0 +1,104 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.python;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.conjure.defs.Conjure;
+import com.palantir.conjure.spec.ConjureDefinition;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+public final class ForceKeywordArgsTest {
+
+    @Test
+    public void testConstructorKeywordArgsAreForced() throws IOException {
+        String generated = generateCode(true);
+
+        assertThat(generated).contains("def __init__(self, *, age: int, email: str, name: str) -> None:");
+    }
+
+    @Test
+    public void testConstructorPositionalArgsByDefault() throws IOException {
+        String generated = generateCode(false);
+
+        assertThat(generated).contains("def __init__(self, age: int, email: str, name: str) -> None:");
+        assertThat(generated).doesNotContain("def __init__(self, *,");
+    }
+
+    @Test
+    public void testUnionKeywordArgsAreForced() throws IOException {
+        String generated = generateCode(true);
+        // The signature spans multiple lines with specific indentation
+        assertThat(generated).contains("    def __init__(\n            self,\n            *,");
+    }
+
+    @Test
+    public void testUnionPositionalArgsByDefault() throws IOException {
+        String generated = generateCode(false);
+
+        // The signature spans multiple lines with specific indentation
+        assertThat(generated).contains("    def __init__(\n            self,\n            foo: Optional[str] = None,");
+        assertThat(generated).doesNotContain("    def __init__(\n            self,\n            *,");
+    }
+
+    @Test
+    public void testServiceEndpointKeywordArgsAreForced() throws IOException {
+        String generated = generateCode(true);
+        assertThat(generated).contains("def test_endpoint(self, *, param1: str, param2: int) -> str:");
+    }
+
+    @Test
+    public void testServiceEndpointPositionalArgsByDefault() throws IOException {
+        String generated = generateCode(false);
+        assertThat(generated).contains("def test_endpoint(self, param1: str, param2: int) -> str:");
+        assertThat(generated).doesNotContain("def test_endpoint(self, *,");
+    }
+
+    @SuppressWarnings("for-rollout:deprecation")
+    private String generateCode(boolean forceKeywordArgs) throws IOException {
+        ConjurePythonGenerator generator = new ConjurePythonGenerator(GeneratorConfiguration.builder()
+                .packageName("test")
+                .packageVersion("0.0.0")
+                .minConjureClientVersion("2.8.0")
+                .generatorVersion("0.0.0")
+                .shouldWriteCondaRecipe(false)
+                .generateRawSource(false)
+                .forceKeywordArgs(forceKeywordArgs)
+                .build());
+
+        Path testFolder = Path.of("src/test/resources/force-keyword-args");
+        List<File> files;
+        try (Stream<Path> walk = Files.walk(testFolder)) {
+            files = walk.map(Path::toFile)
+                    .filter(file -> file.toString().endsWith(".yml"))
+                    .collect(Collectors.toList());
+        }
+        ConjureDefinition definition = Conjure.parse(files);
+
+        InMemoryPythonFileWriter writer = new InMemoryPythonFileWriter();
+        generator.write(definition, writer);
+
+        return writer.getPythonFiles().values().stream().collect(Collectors.joining("\n"));
+    }
+}

--- a/conjure-python-core/src/test/resources/force-keyword-args/expected/conda_recipe/meta.yaml
+++ b/conjure-python-core/src/test/resources/force-keyword-args/expected/conda_recipe/meta.yaml
@@ -1,0 +1,23 @@
+# coding=utf-8
+package:
+    name: package-name
+    version: 0.0.0
+
+source:
+    path: ../
+
+build:
+    noarch: python
+    script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+    build:
+        - python
+        - setuptools
+        - requests
+        - conjure-python-client >=2.8.0,<4
+
+    run:
+        - python
+        - requests
+        - conjure-python-client >=2.8.0,<4

--- a/conjure-python-core/src/test/resources/force-keyword-args/expected/package_name/__init__.py
+++ b/conjure-python-core/src/test/resources/force-keyword-args/expected/package_name/__init__.py
@@ -1,0 +1,9 @@
+# coding=utf-8
+__all__ = [
+    'test_api',
+]
+
+__conjure_generator_version__ = "0.0.0"
+
+__version__ = "0.0.0"
+

--- a/conjure-python-core/src/test/resources/force-keyword-args/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/force-keyword-args/expected/package_name/_impl.py
@@ -1,0 +1,176 @@
+# coding=utf-8
+from abc import (
+    abstractmethod,
+)
+import builtins
+from conjure_python_client import (
+    ConjureBeanType,
+    ConjureDecoder,
+    ConjureEncoder,
+    ConjureFieldDefinition,
+    ConjureUnionType,
+    Service,
+)
+from requests.adapters import (
+    Response,
+)
+from typing import (
+    Any,
+    Dict,
+    List,
+    Optional,
+)
+from urllib.parse import (
+    quote,
+)
+
+class test_api_KeywordArgsTest(ConjureBeanType):
+
+    @builtins.classmethod
+    def _fields(cls) -> Dict[str, ConjureFieldDefinition]:
+        return {
+            'name': ConjureFieldDefinition('name', str),
+            'age': ConjureFieldDefinition('age', int),
+            'email': ConjureFieldDefinition('email', str)
+        }
+
+    __slots__: List[str] = ['_name', '_age', '_email']
+
+    def __init__(self, age: int, email: str, name: str) -> None:
+        self._name = name
+        self._age = age
+        self._email = email
+
+    @builtins.property
+    def name(self) -> str:
+        return self._name
+
+    @builtins.property
+    def age(self) -> int:
+        return self._age
+
+    @builtins.property
+    def email(self) -> str:
+        return self._email
+
+
+test_api_KeywordArgsTest.__name__ = "KeywordArgsTest"
+test_api_KeywordArgsTest.__qualname__ = "KeywordArgsTest"
+test_api_KeywordArgsTest.__module__ = "package_name.test_api"
+
+
+class test_api_TestService(Service):
+
+    def test_endpoint(self, param1: str, param2: int) -> str:
+        _conjure_encoder = ConjureEncoder()
+
+        _headers: Dict[str, Any] = {
+            'Accept': 'application/json',
+        }
+
+        _params: Dict[str, Any] = {
+            'param1': _conjure_encoder.default(param1),
+            'param2': _conjure_encoder.default(param2),
+        }
+
+        _path_params: Dict[str, str] = {
+        }
+
+        _json: Any = None
+
+        _path = '/test/test'
+        _path = _path.format(**_path_params)
+
+        _response: Response = self._request(
+            'POST',
+            self._uri + _path,
+            params=_params,
+            headers=_headers,
+            json=_json)
+
+        _decoder = ConjureDecoder()
+        return _decoder.decode(_response.json(), str, self._return_none_for_unknown_union_types)
+
+
+test_api_TestService.__name__ = "TestService"
+test_api_TestService.__qualname__ = "TestService"
+test_api_TestService.__module__ = "package_name.test_api"
+
+
+class test_api_UnionTest(ConjureUnionType):
+    _foo: Optional[str] = None
+    _bar: Optional[int] = None
+
+    @builtins.classmethod
+    def _options(cls) -> Dict[str, ConjureFieldDefinition]:
+        return {
+            'foo': ConjureFieldDefinition('foo', str),
+            'bar': ConjureFieldDefinition('bar', int)
+        }
+
+    def __init__(
+            self,
+            foo: Optional[str] = None,
+            bar: Optional[int] = None,
+            type_of_union: Optional[str] = None
+            ) -> None:
+        if type_of_union is None:
+            if (foo is not None) + (bar is not None) != 1:
+                raise ValueError('a union must contain a single member')
+
+            if foo is not None:
+                self._foo = foo
+                self._type = 'foo'
+            if bar is not None:
+                self._bar = bar
+                self._type = 'bar'
+
+        elif type_of_union == 'foo':
+            if foo is None:
+                raise ValueError('a union value must not be None')
+            self._foo = foo
+            self._type = 'foo'
+        elif type_of_union == 'bar':
+            if bar is None:
+                raise ValueError('a union value must not be None')
+            self._bar = bar
+            self._type = 'bar'
+
+    @builtins.property
+    def foo(self) -> Optional[str]:
+        return self._foo
+
+    @builtins.property
+    def bar(self) -> Optional[int]:
+        return self._bar
+
+    def accept(self, visitor) -> Any:
+        if not isinstance(visitor, test_api_UnionTestVisitor):
+            raise ValueError('{} is not an instance of test_api_UnionTestVisitor'.format(visitor.__class__.__name__))
+        if self._type == 'foo' and self.foo is not None:
+            return visitor._foo(self.foo)
+        if self._type == 'bar' and self.bar is not None:
+            return visitor._bar(self.bar)
+
+
+test_api_UnionTest.__name__ = "UnionTest"
+test_api_UnionTest.__qualname__ = "UnionTest"
+test_api_UnionTest.__module__ = "package_name.test_api"
+
+
+class test_api_UnionTestVisitor:
+
+    @abstractmethod
+    def _foo(self, foo: str) -> Any:
+        pass
+
+    @abstractmethod
+    def _bar(self, bar: int) -> Any:
+        pass
+
+
+test_api_UnionTestVisitor.__name__ = "UnionTestVisitor"
+test_api_UnionTestVisitor.__qualname__ = "UnionTestVisitor"
+test_api_UnionTestVisitor.__module__ = "package_name.test_api"
+
+

--- a/conjure-python-core/src/test/resources/force-keyword-args/expected/package_name/py.typed
+++ b/conjure-python-core/src/test/resources/force-keyword-args/expected/package_name/py.typed
@@ -1,0 +1,1 @@
+# coding=utf-8

--- a/conjure-python-core/src/test/resources/force-keyword-args/expected/package_name/test_api/__init__.py
+++ b/conjure-python-core/src/test/resources/force-keyword-args/expected/package_name/test_api/__init__.py
@@ -1,0 +1,15 @@
+# coding=utf-8
+from .._impl import (
+    test_api_KeywordArgsTest as KeywordArgsTest,
+    test_api_TestService as TestService,
+    test_api_UnionTest as UnionTest,
+    test_api_UnionTestVisitor as UnionTestVisitor,
+)
+
+__all__ = [
+    'KeywordArgsTest',
+    'UnionTest',
+    'UnionTestVisitor',
+    'TestService',
+]
+

--- a/conjure-python-core/src/test/resources/force-keyword-args/expected/setup.py
+++ b/conjure-python-core/src/test/resources/force-keyword-args/expected/setup.py
@@ -1,0 +1,18 @@
+# coding=utf-8
+from setuptools import (
+    find_packages,
+    setup,
+)
+
+setup(
+    name='package-name',
+    version='0.0.0',
+    python_requires='>=3.8',
+    description='project description',
+    package_data={"": ["py.typed"]},
+    packages=find_packages(),
+    install_requires=[
+        'requests',
+        'conjure-python-client>=2.8.0,<4',
+    ],
+)

--- a/conjure-python-core/src/test/resources/force-keyword-args/test-kwargs.yml
+++ b/conjure-python-core/src/test/resources/force-keyword-args/test-kwargs.yml
@@ -1,0 +1,29 @@
+types:
+  definitions:
+    default-package: test.api
+    objects:
+      KeywordArgsTest:
+        fields:
+          name: string
+          age: integer
+          email: string
+      UnionTest:
+        union:
+          foo: string
+          bar: integer
+services:
+  TestService:
+    name: Test Service
+    package: test.api
+    base-path: /test
+    endpoints:
+      testEndpoint:
+        http: POST /test
+        args:
+          param1:
+            type: string
+            param-type: query
+          param2:
+            type: integer
+            param-type: query
+        returns: string

--- a/conjure-python/src/main/java/com/palantir/conjure/python/cli/CliConfiguration.java
+++ b/conjure-python/src/main/java/com/palantir/conjure/python/cli/CliConfiguration.java
@@ -51,6 +51,12 @@ public abstract class CliConfiguration {
         return false;
     }
 
+    @Value.Default
+    @SuppressWarnings("DesignForExtension")
+    boolean forceKeywordArgs() {
+        return false;
+    }
+
     @Value.Check
     final void check() {
         Preconditions.checkArgument(input().isFile(), "Target must exist and be a file");

--- a/conjure-python/src/main/java/com/palantir/conjure/python/cli/ConjurePythonCli.java
+++ b/conjure-python/src/main/java/com/palantir/conjure/python/cli/ConjurePythonCli.java
@@ -92,7 +92,8 @@ public final class ConjurePythonCli implements Runnable {
         @CommandLine.Option(
                 names = "--force-keyword-args",
                 defaultValue = "false",
-                description = "Force keyword-only arguments in generated constructors. Will become default in v5.0.")
+                description = "Force keyword-only arguments in generated constructors. "
+                        + "Will become default in the next major release.")
         private boolean forceKeywordArgs;
 
         @CommandLine.Unmatched

--- a/conjure-python/src/main/java/com/palantir/conjure/python/cli/ConjurePythonCli.java
+++ b/conjure-python/src/main/java/com/palantir/conjure/python/cli/ConjurePythonCli.java
@@ -89,6 +89,12 @@ public final class ConjurePythonCli implements Runnable {
                 description = "Generate a `conda_recipe/meta.yaml`")
         private boolean writeCondaRecipe;
 
+        @CommandLine.Option(
+                names = "--force-keyword-args",
+                defaultValue = "false",
+                description = "Force keyword-only arguments in generated constructors. Will become default in v5.0.")
+        private boolean forceKeywordArgs;
+
         @CommandLine.Unmatched
         @SuppressWarnings("StrictUnusedVariable")
         private List<String> unmatchedOptions;
@@ -118,6 +124,7 @@ public final class ConjurePythonCli implements Runnable {
                     .packageUrl(Optional.ofNullable(packageUrl))
                     .generateRawSource(rawSource)
                     .shouldWriteCondaRecipe(writeCondaRecipe)
+                    .forceKeywordArgs(forceKeywordArgs)
                     .build();
         }
 
@@ -134,6 +141,7 @@ public final class ConjurePythonCli implements Runnable {
                     .packageUrl(cliConfig.packageUrl())
                     .shouldWriteCondaRecipe(cliConfig.shouldWriteCondaRecipe())
                     .generateRawSource(cliConfig.generateRawSource())
+                    .forceKeywordArgs(cliConfig.forceKeywordArgs())
                     .build();
         }
     }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

Addressing issue https://github.com/palantir/conjure-python/issues/19, implicitly addressing issue https://github.com/palantir/conjure-python/issues/55.

Positional args are not ideal because, combining with the fact that [`conjure-python` alphabetically sorts the arg list](https://github.com/palantir/conjure-python/issues/55), the approach is just not set up for backward compatibility. Whenever a new `optional` (otherwise it's deemed a breaking change) item is added to the Conjure definiton, the dev better hopes the generated API isn't invoked positionally otherwise the consuming callsites will likely break. For the back compat, they need to make sure the generated argument ends up at the very end of the arg list (sometimes involving wittedly naming the variable which is sad and I have personally had the convo internally) so that they can get assigned a default `None` properly. Additionally, when the list is too long, the invoking code could be barely readable in positional style (without comments). And if there are comments, it's effectively keyword style invocation. 

Why can't we just not sort the arg list and keep the rest status quo? Because even though it does address most of the back compat issues, it can still occur if the item is somehow added to the middle of the Conjure definitions and the callsites are positionally invoked. Enforcing kwargs will get rid of this headache once and for all. And practically, I don't think this will involve a lot of changes on the consumers' end (see Possible downsides below), making it a pretty good ROI.

## After this PR

Introducing a CLI flag that determines whether to force kwargs or not. The generated code of targets are bean type constructor args, union type constructor args, and API endpoints. 

The particular changes are mostly threading through the callstacks, logic for generating '*', and unit test.

**Disclaimer: I used Claude Code to create just the boilerplate of the unit test, cause I don't like plumbing work ;)**

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add an option to force keyword arguments
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

For now, the flag defaults to `false` so it's fully backward compatible.

However, going forward we do plan to enforce it in the next major release. This means all the consumers for the affected generated code will need to be invoked keyword-only. However, 1) Anecdotally, my observation internally suggests that majority (if not all) of the consumers of the generated code are already using kwargs invocation 2) Given the back compat trouble mentioned earlier, it's just not safe to use positional style unless it's a oneoff, so some people might already realize this and are doing kwargs invocations. TLDR it's either you're effectively already doing it or what you're doing is unsafe and you better move off of it situation. And we should enforce the better practice, but definitely with considerate rollout.