### PR TITLE
Feature: Add an option to generate exceptions for Conjure errors

### DIFF
--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/ConjurePythonGenerator.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/ConjurePythonGenerator.java
@@ -42,6 +42,7 @@ import com.palantir.conjure.python.processors.typename.NameOnlyTypeNameProcessor
 import com.palantir.conjure.python.processors.typename.PackagePrependingTypeNameProcessor;
 import com.palantir.conjure.python.processors.typename.TypeNameProcessor;
 import com.palantir.conjure.python.types.DefinitionImportTypeDefinitionVisitor;
+import com.palantir.conjure.python.types.PythonErrorGenerator;
 import com.palantir.conjure.python.types.PythonTypeGenerator;
 import com.palantir.conjure.spec.ConjureDefinition;
 import com.palantir.conjure.spec.TypeName;
@@ -146,6 +147,12 @@ public final class ConjurePythonGenerator {
                 definitionPackageNameProcessor,
                 definitionTypeNameProcessor,
                 dealiasingTypeVisitor);
+        PythonErrorGenerator errorGenerator = new PythonErrorGenerator(
+                implPackageNameProcessor,
+                implTypeNameProcessor,
+                definitionPackageNameProcessor,
+                definitionTypeNameProcessor,
+                dealiasingTypeVisitor);
 
         List<PythonSnippet> snippets = new ArrayList<>();
         snippets.addAll(conjureDefinition.getTypes().stream()
@@ -154,6 +161,11 @@ public final class ConjurePythonGenerator {
         snippets.addAll(conjureDefinition.getServices().stream()
                 .map(clientGenerator::generateClient)
                 .toList());
+        if (config.generateErrorTypes()) {
+            snippets.addAll(conjureDefinition.getErrors().stream()
+                    .map(errorGenerator::generateError)
+                    .toList());
+        }
 
         Map<PythonPackage, List<PythonSnippet>> snippetsByPackage =
                 snippets.stream().collect(Collectors.groupingBy(PythonSnippet::pythonPackage));
@@ -202,6 +214,19 @@ public final class ConjurePythonGenerator {
                             definitionTypeNameProcessor.process(serviceDefinition.getServiceName())));
             importsByPackage.put(pythonPackage, pythonImport);
         });
+
+        if (config.generateErrorTypes()) {
+            conjureDefinition.getErrors().forEach(errorDefinition -> {
+                PythonPackage pythonPackage = PythonPackage.of(definitionPackageNameProcessor.process(
+                        errorDefinition.getErrorName().getPackage()));
+                PythonImport pythonImport = PythonImport.of(
+                        moduleSpecifier,
+                        NamedImport.of(
+                                implTypeNameProcessor.process(errorDefinition.getErrorName()),
+                                definitionTypeNameProcessor.process(errorDefinition.getErrorName())));
+                importsByPackage.put(pythonPackage, pythonImport);
+            });
+        }
 
         return KeyedStream.stream(importsByPackage.build().asMap())
                 .map((pythonPackage, imports) -> {

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/GeneratorConfiguration.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/GeneratorConfiguration.java
@@ -43,6 +43,11 @@ public interface GeneratorConfiguration {
 
     boolean generateRawSource();
 
+    @Value.Default
+    default boolean generateErrorTypes() {
+        return false;
+    }
+
     default Optional<String> pythonicPackageName() {
         return packageName().map(packageName -> packageName.replace('-', '_'));
     }

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/GeneratorConfiguration.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/GeneratorConfiguration.java
@@ -43,10 +43,7 @@ public interface GeneratorConfiguration {
 
     boolean generateRawSource();
 
-    @Value.Default
-    default boolean generateErrorTypes() {
-        return false;
-    }
+    boolean generateErrorTypes();
 
     default Optional<String> pythonicPackageName() {
         return packageName().map(packageName -> packageName.replace('-', '_'));

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/ErrorSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/ErrorSnippet.java
@@ -31,6 +31,7 @@ public interface ErrorSnippet extends PythonSnippet {
                     .moduleSpecifier(ImportTypeVisitor.CONJURE_PYTHON_CLIENT)
                     .addNamedImports(NamedImport.of("ConjureHTTPError"))
                     .build(),
+            PythonImport.of("builtins"),
             PythonImport.builder()
                     .moduleSpecifier(ImportTypeVisitor.TYPING)
                     .addNamedImports(NamedImport.of("TypedDict"))
@@ -66,10 +67,11 @@ public interface ErrorSnippet extends PythonSnippet {
 
         poetWriter.writeLine();
 
-        // Error constants
+        // Error constants. ERROR_NAME is the fully-qualified wire form (e.g. "Datasets:DatasetNotFound") and
+        // matches the value of ConjureHTTPError.error_name parsed from the response body.
         poetWriter.writeIndentedLine(String.format("ERROR_CODE = \"%s\"", errorCode()));
         poetWriter.writeIndentedLine(String.format("ERROR_NAMESPACE = \"%s\"", namespace()));
-        poetWriter.writeIndentedLine(String.format("ERROR_NAME = \"%s\"", definitionName()));
+        poetWriter.writeIndentedLine(String.format("ERROR_NAME = \"%s:%s\"", namespace(), definitionName()));
 
         poetWriter.writeLine();
 
@@ -136,16 +138,18 @@ public interface ErrorSnippet extends PythonSnippet {
         for (int i = 0; i < fields.size(); i++) {
             PythonField field = fields.get(i);
             String comma = i == fields.size() - 1 ? "" : ",";
+            String lookup = field.isOptional()
+                    ? String.format("base_error.parameters.get('%s')", field.jsonIdentifier())
+                    : String.format("base_error.parameters['%s']", field.jsonIdentifier());
             poetWriter.writeIndentedLine(String.format(
-                    "'%s': base_error.parameters['%s']%s",
-                    PythonIdentifierSanitizer.sanitize(field.attributeName()), field.jsonIdentifier(), comma));
+                    "'%s': %s%s", PythonIdentifierSanitizer.sanitize(field.attributeName()), lookup, comma));
         }
         poetWriter.decreaseIndent();
         poetWriter.writeIndentedLine("}");
     }
 
     default void emitIsInstanceMethod(PythonPoetWriter poetWriter) {
-        poetWriter.writeIndentedLine("@classmethod");
+        poetWriter.writeIndentedLine("@builtins.classmethod");
         poetWriter.writeIndentedLine("def is_instance(cls, error: ConjureHTTPError) -> bool:");
         poetWriter.increaseIndent();
         poetWriter.writeIndentedLine("return (");
@@ -159,13 +163,13 @@ public interface ErrorSnippet extends PythonSnippet {
     }
 
     default void emitFromErrorMethod(PythonPoetWriter poetWriter) {
-        poetWriter.writeIndentedLine("@classmethod");
+        poetWriter.writeIndentedLine("@builtins.classmethod");
         poetWriter.writeIndentedLine(
                 String.format("def from_error(cls, error: ConjureHTTPError) -> '%s':", className()));
         poetWriter.increaseIndent();
         poetWriter.writeIndentedLine("if not cls.is_instance(error):");
         poetWriter.increaseIndent();
-        poetWriter.writeIndentedLine("raise ValueError(f\"Error is not a {cls.ERROR_NAME}\")");
+        poetWriter.writeIndentedLine("raise ValueError(f\"Error '{error.error_name}' is not a {cls.ERROR_NAME}\")");
         poetWriter.decreaseIndent();
         poetWriter.writeIndentedLine("return cls(error)");
         poetWriter.decreaseIndent();

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/ErrorSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/ErrorSnippet.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,14 +73,13 @@ public interface ErrorSnippet extends PythonSnippet {
 
         poetWriter.writeLine();
 
-        // TypedDicts for args
+        // args
         emitTypedDict(poetWriter, "SafeArgs", safeArgs());
         emitTypedDict(poetWriter, "UnsafeArgs", unsafeArgs());
 
-        // Constructor
         emitConstructor(poetWriter);
 
-        // Classmethods
+        // classmethods
         emitIsInstanceMethod(poetWriter);
         emitFromErrorMethod(poetWriter);
 
@@ -93,16 +92,17 @@ public interface ErrorSnippet extends PythonSnippet {
     }
 
     default void emitTypedDict(PythonPoetWriter poetWriter, String typedDictName, List<PythonField> fields) {
-        if (!fields.isEmpty()) {
-            poetWriter.writeIndentedLine(String.format("class %s(TypedDict):", typedDictName));
-            poetWriter.increaseIndent();
-            for (PythonField field : fields) {
-                poetWriter.writeIndentedLine(String.format(
-                        "%s: %s", PythonIdentifierSanitizer.sanitize(field.attributeName()), field.myPyType()));
-            }
-            poetWriter.decreaseIndent();
-            poetWriter.writeLine();
+        if (fields.isEmpty()) {
+            return;
         }
+        poetWriter.writeIndentedLine(String.format("class %s(TypedDict):", typedDictName));
+        poetWriter.increaseIndent();
+        for (PythonField field : fields) {
+            poetWriter.writeIndentedLine(String.format(
+                    "%s: %s", PythonIdentifierSanitizer.sanitize(field.attributeName()), field.myPyType()));
+        }
+        poetWriter.decreaseIndent();
+        poetWriter.writeLine();
     }
 
     default void emitConstructor(PythonPoetWriter poetWriter) {
@@ -111,6 +111,7 @@ public interface ErrorSnippet extends PythonSnippet {
         poetWriter.writeIndentedLine("super().__init__(");
         poetWriter.increaseIndent();
         poetWriter.writeIndentedLine("status_code=base_error.status_code,");
+        // TODO(bzhang): Use enum once https://github.com/palantir/conjure-python-client/pull/171 is merged
         poetWriter.writeIndentedLine("error_code=base_error.error_code,");
         poetWriter.writeIndentedLine("error_name=base_error.error_name,");
         poetWriter.writeIndentedLine("error_instance_id=base_error.error_instance_id,");
@@ -127,19 +128,20 @@ public interface ErrorSnippet extends PythonSnippet {
 
     default void emitArgsParser(
             PythonPoetWriter poetWriter, String fieldName, String typeName, List<PythonField> fields) {
-        if (!fields.isEmpty()) {
-            poetWriter.writeIndentedLine(String.format("self.%s: %s.%s = {", fieldName, className(), typeName));
-            poetWriter.increaseIndent();
-            for (int i = 0; i < fields.size(); i++) {
-                PythonField field = fields.get(i);
-                String comma = i == fields.size() - 1 ? "" : ",";
-                poetWriter.writeIndentedLine(String.format(
-                        "'%s': base_error.parameters['%s']%s",
-                        PythonIdentifierSanitizer.sanitize(field.attributeName()), field.jsonIdentifier(), comma));
-            }
-            poetWriter.decreaseIndent();
-            poetWriter.writeIndentedLine("}");
+        if (fields.isEmpty()) {
+            return;
         }
+        poetWriter.writeIndentedLine(String.format("self.%s: %s.%s = {", fieldName, className(), typeName));
+        poetWriter.increaseIndent();
+        for (int i = 0; i < fields.size(); i++) {
+            PythonField field = fields.get(i);
+            String comma = i == fields.size() - 1 ? "" : ",";
+            poetWriter.writeIndentedLine(String.format(
+                    "'%s': base_error.parameters['%s']%s",
+                    PythonIdentifierSanitizer.sanitize(field.attributeName()), field.jsonIdentifier(), comma));
+        }
+        poetWriter.decreaseIndent();
+        poetWriter.writeIndentedLine("}");
     }
 
     default void emitIsInstanceMethod(PythonPoetWriter poetWriter) {

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/ErrorSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/ErrorSnippet.java
@@ -148,7 +148,6 @@ public interface ErrorSnippet extends PythonSnippet {
         poetWriter.writeIndentedLine("@classmethod");
         poetWriter.writeIndentedLine("def is_instance(cls, error: ConjureHTTPError) -> bool:");
         poetWriter.increaseIndent();
-        poetWriter.writeIndentedLine("\"\"\"Check if a ConjureHTTPError is this specific error type\"\"\"");
         poetWriter.writeIndentedLine("return (");
         poetWriter.increaseIndent();
         poetWriter.writeIndentedLine("error.error_name == cls.ERROR_NAME and");
@@ -164,7 +163,6 @@ public interface ErrorSnippet extends PythonSnippet {
         poetWriter.writeIndentedLine(
                 String.format("def from_error(cls, error: ConjureHTTPError) -> '%s':", className()));
         poetWriter.increaseIndent();
-        poetWriter.writeIndentedLine("\"\"\"Convert a generic ConjureHTTPError to this typed error\"\"\"");
         poetWriter.writeIndentedLine("if not cls.is_instance(error):");
         poetWriter.increaseIndent();
         poetWriter.writeIndentedLine("raise ValueError(f\"Error is not a {cls.ERROR_NAME}\")");

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/ErrorSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/ErrorSnippet.java
@@ -31,11 +31,12 @@ public interface ErrorSnippet extends PythonSnippet {
                     .moduleSpecifier(ImportTypeVisitor.CONJURE_PYTHON_CLIENT)
                     .addNamedImports(NamedImport.of("ConjureHTTPError"))
                     .build(),
-            PythonImport.of("builtins"),
-            PythonImport.builder()
-                    .moduleSpecifier(ImportTypeVisitor.TYPING)
-                    .addNamedImports(NamedImport.of("TypedDict"))
-                    .build());
+            PythonImport.of("builtins"));
+
+    PythonImport TYPED_DICT_IMPORT = PythonImport.builder()
+            .moduleSpecifier(ImportTypeVisitor.TYPING)
+            .addNamedImports(NamedImport.of("TypedDict"))
+            .build();
 
     @Override
     @Value.Default
@@ -113,7 +114,6 @@ public interface ErrorSnippet extends PythonSnippet {
         poetWriter.writeIndentedLine("super().__init__(");
         poetWriter.increaseIndent();
         poetWriter.writeIndentedLine("status_code=base_error.status_code,");
-        // TODO(bzhang): Use enum once https://github.com/palantir/conjure-python-client/pull/171 is merged
         poetWriter.writeIndentedLine("error_code=base_error.error_code,");
         poetWriter.writeIndentedLine("error_name=base_error.error_name,");
         poetWriter.writeIndentedLine("error_instance_id=base_error.error_instance_id,");
@@ -152,12 +152,7 @@ public interface ErrorSnippet extends PythonSnippet {
         poetWriter.writeIndentedLine("@builtins.classmethod");
         poetWriter.writeIndentedLine("def is_instance(cls, error: ConjureHTTPError) -> bool:");
         poetWriter.increaseIndent();
-        poetWriter.writeIndentedLine("return (");
-        poetWriter.increaseIndent();
-        poetWriter.writeIndentedLine("error.error_name == cls.ERROR_NAME and");
-        poetWriter.writeIndentedLine("error.error_code == cls.ERROR_CODE");
-        poetWriter.decreaseIndent();
-        poetWriter.writeIndentedLine(")");
+        poetWriter.writeIndentedLine("return error.error_name == cls.ERROR_NAME");
         poetWriter.decreaseIndent();
         poetWriter.writeLine();
     }

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/ErrorSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/ErrorSnippet.java
@@ -33,6 +33,7 @@ public interface ErrorSnippet extends PythonSnippet {
                     .addNamedImports(NamedImport.of("ConjureDecoder"))
                     .build(),
             PythonImport.of("builtins"),
+            PythonImport.of("json"),
             PythonImport.of("uuid"),
             PythonImport.builder()
                     .moduleSpecifier(ImportTypeVisitor.TYPING)
@@ -85,6 +86,9 @@ public interface ErrorSnippet extends PythonSnippet {
         poetWriter.writeLine();
 
         emitConstructor(poetWriter);
+        if (!args().isEmpty()) {
+            emitProperties(poetWriter);
+        }
         emitEncode(poetWriter);
         emitDecode(poetWriter);
 
@@ -107,13 +111,25 @@ public interface ErrorSnippet extends PythonSnippet {
         poetWriter.increaseIndent();
         for (PythonField field : args()) {
             String attribute = PythonIdentifierSanitizer.sanitize(field.attributeName());
-            poetWriter.writeIndentedLine(String.format("self.%s = %s", attribute, attribute));
+            poetWriter.writeIndentedLine(String.format("self._%s = %s", attribute, attribute));
         }
         poetWriter.writeIndentedLine("self.error_instance_id = error_instance_id if error_instance_id is not None "
                 + "else str(uuid.uuid4())");
         poetWriter.writeIndentedLine("super().__init__(self.ERROR_NAME)");
         poetWriter.decreaseIndent();
         poetWriter.writeLine();
+    }
+
+    default void emitProperties(PythonPoetWriter poetWriter) {
+        for (PythonField field : args()) {
+            String attribute = PythonIdentifierSanitizer.sanitize(field.attributeName());
+            poetWriter.writeIndentedLine("@builtins.property");
+            poetWriter.writeIndentedLine(String.format("def %s(self) -> %s:", attribute, field.myPyType()));
+            poetWriter.increaseIndent();
+            poetWriter.writeIndentedLine(String.format("return self._%s", attribute));
+            poetWriter.decreaseIndent();
+            poetWriter.writeLine();
+        }
     }
 
     default void emitEncode(PythonPoetWriter poetWriter) {
@@ -143,6 +159,28 @@ public interface ErrorSnippet extends PythonSnippet {
     }
 
     default void emitDecode(PythonPoetWriter poetWriter) {
+        List<PythonField> args = args();
+        if (!args.isEmpty()) {
+            poetWriter.writeIndentedLine("@builtins.staticmethod");
+            poetWriter.writeIndentedLine(
+                    "def _decode_parameter(decoder: ConjureDecoder, value: Any, conjure_type: Any) -> Any:");
+            poetWriter.increaseIndent();
+            poetWriter.writeIndentedLine("if isinstance(value, str) and conjure_type is not str:");
+            poetWriter.increaseIndent();
+            poetWriter.writeIndentedLine("try:");
+            poetWriter.increaseIndent();
+            poetWriter.writeIndentedLine("value = json.loads(value)");
+            poetWriter.decreaseIndent();
+            poetWriter.writeIndentedLine("except (ValueError, TypeError):");
+            poetWriter.increaseIndent();
+            poetWriter.writeIndentedLine("pass");
+            poetWriter.decreaseIndent();
+            poetWriter.decreaseIndent();
+            poetWriter.writeIndentedLine("return decoder.decode(value, conjure_type)");
+            poetWriter.decreaseIndent();
+            poetWriter.writeLine();
+        }
+
         poetWriter.writeIndentedLine("@builtins.classmethod");
         poetWriter.writeIndentedLine(String.format("def decode(cls, error: Dict[str, Any]) -> '%s':", className()));
         poetWriter.increaseIndent();
@@ -152,7 +190,6 @@ public interface ErrorSnippet extends PythonSnippet {
                 "raise ValueError(f\"Error '{error.get('errorName')}' is not a {cls.ERROR_NAME}\")");
         poetWriter.decreaseIndent();
 
-        List<PythonField> args = args();
         if (!args.isEmpty()) {
             poetWriter.writeIndentedLine("decoder = ConjureDecoder()");
             poetWriter.writeIndentedLine("parameters = error.get('parameters', {})");
@@ -162,7 +199,7 @@ public interface ErrorSnippet extends PythonSnippet {
         poetWriter.increaseIndent();
         for (PythonField field : args) {
             poetWriter.writeIndentedLine(String.format(
-                    "%s=decoder.decode(parameters.get('%s'), %s),",
+                    "%s=cls._decode_parameter(decoder, parameters.get('%s'), %s),",
                     PythonIdentifierSanitizer.sanitize(field.attributeName()),
                     field.jsonIdentifier(),
                     field.pythonType()));

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/ErrorSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/ErrorSnippet.java
@@ -1,0 +1,179 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.python.poet;
+
+import com.google.common.collect.ImmutableList;
+import com.palantir.conjure.python.processors.PythonIdentifierSanitizer;
+import com.palantir.conjure.python.types.ImportTypeVisitor;
+import com.palantir.conjure.spec.Documentation;
+import java.util.List;
+import java.util.Optional;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface ErrorSnippet extends PythonSnippet {
+    ImmutableList<PythonImport> DEFAULT_IMPORTS = ImmutableList.of(
+            PythonImport.builder()
+                    .moduleSpecifier(ImportTypeVisitor.CONJURE_PYTHON_CLIENT)
+                    .addNamedImports(NamedImport.of("ConjureHTTPError"))
+                    .build(),
+            PythonImport.builder()
+                    .moduleSpecifier(ImportTypeVisitor.TYPING)
+                    .addNamedImports(NamedImport.of("TypedDict"))
+                    .build());
+
+    @Override
+    @Value.Default
+    default String idForSorting() {
+        return className();
+    }
+
+    String className();
+
+    String definitionName();
+
+    PythonPackage definitionPackage();
+
+    Optional<Documentation> docs();
+
+    String errorCode();
+
+    String namespace();
+
+    List<PythonField> safeArgs();
+
+    List<PythonField> unsafeArgs();
+
+    @Override
+    default void emit(PythonPoetWriter poetWriter) {
+        poetWriter.writeIndentedLine(String.format("class %s(ConjureHTTPError):", className()));
+        poetWriter.increaseIndent();
+        docs().ifPresent(poetWriter::writeDocs);
+
+        poetWriter.writeLine();
+
+        // Error constants
+        poetWriter.writeIndentedLine(String.format("ERROR_CODE = \"%s\"", errorCode()));
+        poetWriter.writeIndentedLine(String.format("ERROR_NAMESPACE = \"%s\"", namespace()));
+        poetWriter.writeIndentedLine(String.format("ERROR_NAME = \"%s\"", definitionName()));
+
+        poetWriter.writeLine();
+
+        // TypedDicts for args
+        emitTypedDict(poetWriter, "SafeArgs", safeArgs());
+        emitTypedDict(poetWriter, "UnsafeArgs", unsafeArgs());
+
+        // Constructor
+        emitConstructor(poetWriter);
+
+        // Classmethods
+        emitIsInstanceMethod(poetWriter);
+        emitFromErrorMethod(poetWriter);
+
+        // end of class def
+        poetWriter.decreaseIndent();
+        poetWriter.writeLine();
+        poetWriter.writeLine();
+
+        PythonClassRenamer.renameClass(poetWriter, className(), definitionPackage(), definitionName());
+    }
+
+    default void emitTypedDict(PythonPoetWriter poetWriter, String typedDictName, List<PythonField> fields) {
+        if (!fields.isEmpty()) {
+            poetWriter.writeIndentedLine(String.format("class %s(TypedDict):", typedDictName));
+            poetWriter.increaseIndent();
+            for (PythonField field : fields) {
+                poetWriter.writeIndentedLine(String.format(
+                        "%s: %s", PythonIdentifierSanitizer.sanitize(field.attributeName()), field.myPyType()));
+            }
+            poetWriter.decreaseIndent();
+            poetWriter.writeLine();
+        }
+    }
+
+    default void emitConstructor(PythonPoetWriter poetWriter) {
+        poetWriter.writeIndentedLine("def __init__(self, base_error: ConjureHTTPError) -> None:");
+        poetWriter.increaseIndent();
+        poetWriter.writeIndentedLine("super().__init__(");
+        poetWriter.increaseIndent();
+        poetWriter.writeIndentedLine("status_code=base_error.status_code,");
+        poetWriter.writeIndentedLine("error_code=base_error.error_code,");
+        poetWriter.writeIndentedLine("error_name=base_error.error_name,");
+        poetWriter.writeIndentedLine("error_instance_id=base_error.error_instance_id,");
+        poetWriter.writeIndentedLine("parameters=base_error.parameters");
+        poetWriter.decreaseIndent();
+        poetWriter.writeIndentedLine(")");
+
+        emitArgsParser(poetWriter, "safe_args", "SafeArgs", safeArgs());
+        emitArgsParser(poetWriter, "unsafe_args", "UnsafeArgs", unsafeArgs());
+
+        poetWriter.decreaseIndent();
+        poetWriter.writeLine();
+    }
+
+    default void emitArgsParser(
+            PythonPoetWriter poetWriter, String fieldName, String typeName, List<PythonField> fields) {
+        if (!fields.isEmpty()) {
+            poetWriter.writeIndentedLine(String.format("self.%s: %s.%s = {", fieldName, className(), typeName));
+            poetWriter.increaseIndent();
+            for (int i = 0; i < fields.size(); i++) {
+                PythonField field = fields.get(i);
+                String comma = i == fields.size() - 1 ? "" : ",";
+                poetWriter.writeIndentedLine(String.format(
+                        "'%s': base_error.parameters['%s']%s",
+                        PythonIdentifierSanitizer.sanitize(field.attributeName()), field.jsonIdentifier(), comma));
+            }
+            poetWriter.decreaseIndent();
+            poetWriter.writeIndentedLine("}");
+        }
+    }
+
+    default void emitIsInstanceMethod(PythonPoetWriter poetWriter) {
+        poetWriter.writeIndentedLine("@classmethod");
+        poetWriter.writeIndentedLine("def is_instance(cls, error: ConjureHTTPError) -> bool:");
+        poetWriter.increaseIndent();
+        poetWriter.writeIndentedLine("\"\"\"Check if a ConjureHTTPError is this specific error type\"\"\"");
+        poetWriter.writeIndentedLine("return (");
+        poetWriter.increaseIndent();
+        poetWriter.writeIndentedLine("error.error_name == cls.ERROR_NAME and");
+        poetWriter.writeIndentedLine("error.error_code == cls.ERROR_CODE");
+        poetWriter.decreaseIndent();
+        poetWriter.writeIndentedLine(")");
+        poetWriter.decreaseIndent();
+        poetWriter.writeLine();
+    }
+
+    default void emitFromErrorMethod(PythonPoetWriter poetWriter) {
+        poetWriter.writeIndentedLine("@classmethod");
+        poetWriter.writeIndentedLine(
+                String.format("def from_error(cls, error: ConjureHTTPError) -> '%s':", className()));
+        poetWriter.increaseIndent();
+        poetWriter.writeIndentedLine("\"\"\"Convert a generic ConjureHTTPError to this typed error\"\"\"");
+        poetWriter.writeIndentedLine("if not cls.is_instance(error):");
+        poetWriter.increaseIndent();
+        poetWriter.writeIndentedLine("raise ValueError(f\"Error is not a {cls.ERROR_NAME}\")");
+        poetWriter.decreaseIndent();
+        poetWriter.writeIndentedLine("return cls(error)");
+        poetWriter.decreaseIndent();
+    }
+
+    class Builder extends ImmutableErrorSnippet.Builder {}
+
+    static Builder builder() {
+        return new Builder();
+    }
+}

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/ErrorSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/ErrorSnippet.java
@@ -33,7 +33,6 @@ public interface ErrorSnippet extends PythonSnippet {
                     .addNamedImports(NamedImport.of("ConjureDecoder"))
                     .build(),
             PythonImport.of("builtins"),
-            PythonImport.of("json"),
             PythonImport.of("uuid"),
             PythonImport.builder()
                     .moduleSpecifier(ImportTypeVisitor.TYPING)
@@ -160,27 +159,6 @@ public interface ErrorSnippet extends PythonSnippet {
 
     default void emitDecode(PythonPoetWriter poetWriter) {
         List<PythonField> args = args();
-        if (!args.isEmpty()) {
-            poetWriter.writeIndentedLine("@builtins.staticmethod");
-            poetWriter.writeIndentedLine(
-                    "def _decode_parameter(decoder: ConjureDecoder, value: Any, conjure_type: Any) -> Any:");
-            poetWriter.increaseIndent();
-            poetWriter.writeIndentedLine("if isinstance(value, str) and conjure_type is not str:");
-            poetWriter.increaseIndent();
-            poetWriter.writeIndentedLine("try:");
-            poetWriter.increaseIndent();
-            poetWriter.writeIndentedLine("value = json.loads(value)");
-            poetWriter.decreaseIndent();
-            poetWriter.writeIndentedLine("except (ValueError, TypeError):");
-            poetWriter.increaseIndent();
-            poetWriter.writeIndentedLine("pass");
-            poetWriter.decreaseIndent();
-            poetWriter.decreaseIndent();
-            poetWriter.writeIndentedLine("return decoder.decode(value, conjure_type)");
-            poetWriter.decreaseIndent();
-            poetWriter.writeLine();
-        }
-
         poetWriter.writeIndentedLine("@builtins.classmethod");
         poetWriter.writeIndentedLine(String.format("def decode(cls, error: Dict[str, Any]) -> '%s':", className()));
         poetWriter.increaseIndent();
@@ -199,7 +177,7 @@ public interface ErrorSnippet extends PythonSnippet {
         poetWriter.increaseIndent();
         for (PythonField field : args) {
             poetWriter.writeIndentedLine(String.format(
-                    "%s=cls._decode_parameter(decoder, parameters.get('%s'), %s),",
+                    "%s=decoder.decode(parameters.get('%s'), %s),",
                     PythonIdentifierSanitizer.sanitize(field.attributeName()),
                     field.jsonIdentifier(),
                     field.pythonType()));

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/ErrorSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/ErrorSnippet.java
@@ -29,14 +29,17 @@ public interface ErrorSnippet extends PythonSnippet {
     ImmutableList<PythonImport> DEFAULT_IMPORTS = ImmutableList.of(
             PythonImport.builder()
                     .moduleSpecifier(ImportTypeVisitor.CONJURE_PYTHON_CLIENT)
-                    .addNamedImports(NamedImport.of("ConjureHTTPError"))
+                    .addNamedImports(NamedImport.of("ConjureEncoder"))
+                    .addNamedImports(NamedImport.of("ConjureDecoder"))
                     .build(),
-            PythonImport.of("builtins"));
-
-    PythonImport TYPED_DICT_IMPORT = PythonImport.builder()
-            .moduleSpecifier(ImportTypeVisitor.TYPING)
-            .addNamedImports(NamedImport.of("TypedDict"))
-            .build();
+            PythonImport.of("builtins"),
+            PythonImport.of("uuid"),
+            PythonImport.builder()
+                    .moduleSpecifier(ImportTypeVisitor.TYPING)
+                    .addNamedImports(NamedImport.of("Any"))
+                    .addNamedImports(NamedImport.of("Dict"))
+                    .addNamedImports(NamedImport.of("Optional"))
+                    .build());
 
     @Override
     @Value.Default
@@ -60,33 +63,31 @@ public interface ErrorSnippet extends PythonSnippet {
 
     List<PythonField> unsafeArgs();
 
+    default List<PythonField> args() {
+        return ImmutableList.<PythonField>builder()
+                .addAll(safeArgs())
+                .addAll(unsafeArgs())
+                .build();
+    }
+
     @Override
     default void emit(PythonPoetWriter poetWriter) {
-        poetWriter.writeIndentedLine(String.format("class %s(ConjureHTTPError):", className()));
+        poetWriter.writeIndentedLine(String.format("class %s(Exception):", className()));
         poetWriter.increaseIndent();
         docs().ifPresent(poetWriter::writeDocs);
 
         poetWriter.writeLine();
 
-        // Error constants. ERROR_NAME is the fully-qualified wire form (e.g. "Datasets:DatasetNotFound") and
-        // matches the value of ConjureHTTPError.error_name parsed from the response body.
         poetWriter.writeIndentedLine(String.format("ERROR_CODE = \"%s\"", errorCode()));
         poetWriter.writeIndentedLine(String.format("ERROR_NAMESPACE = \"%s\"", namespace()));
         poetWriter.writeIndentedLine(String.format("ERROR_NAME = \"%s:%s\"", namespace(), definitionName()));
 
         poetWriter.writeLine();
 
-        // args
-        emitTypedDict(poetWriter, "SafeArgs", safeArgs());
-        emitTypedDict(poetWriter, "UnsafeArgs", unsafeArgs());
-
         emitConstructor(poetWriter);
+        emitEncode(poetWriter);
+        emitDecode(poetWriter);
 
-        // classmethods
-        emitIsInstanceMethod(poetWriter);
-        emitFromErrorMethod(poetWriter);
-
-        // end of class def
         poetWriter.decreaseIndent();
         poetWriter.writeLine();
         poetWriter.writeLine();
@@ -94,79 +95,81 @@ public interface ErrorSnippet extends PythonSnippet {
         PythonClassRenamer.renameClass(poetWriter, className(), definitionPackage(), definitionName());
     }
 
-    default void emitTypedDict(PythonPoetWriter poetWriter, String typedDictName, List<PythonField> fields) {
-        if (fields.isEmpty()) {
-            return;
-        }
-        poetWriter.writeIndentedLine(String.format("class %s(TypedDict):", typedDictName));
-        poetWriter.increaseIndent();
-        for (PythonField field : fields) {
-            poetWriter.writeIndentedLine(String.format(
-                    "%s: %s", PythonIdentifierSanitizer.sanitize(field.attributeName()), field.myPyType()));
-        }
-        poetWriter.decreaseIndent();
-        poetWriter.writeLine();
-    }
-
     default void emitConstructor(PythonPoetWriter poetWriter) {
-        poetWriter.writeIndentedLine("def __init__(self, base_error: ConjureHTTPError) -> None:");
-        poetWriter.increaseIndent();
-        poetWriter.writeIndentedLine("super().__init__(");
-        poetWriter.increaseIndent();
-        poetWriter.writeIndentedLine("status_code=base_error.status_code,");
-        poetWriter.writeIndentedLine("error_code=base_error.error_code,");
-        poetWriter.writeIndentedLine("error_name=base_error.error_name,");
-        poetWriter.writeIndentedLine("error_instance_id=base_error.error_instance_id,");
-        poetWriter.writeIndentedLine("parameters=base_error.parameters");
-        poetWriter.decreaseIndent();
-        poetWriter.writeIndentedLine(")");
+        StringBuilder signature = new StringBuilder("def __init__(self");
+        for (PythonField field : args()) {
+            signature.append(String.format(
+                    ", %s: %s", PythonIdentifierSanitizer.sanitize(field.attributeName()), field.myPyType()));
+        }
+        signature.append(", error_instance_id: Optional[str] = None) -> None:");
+        poetWriter.writeIndentedLine(signature.toString());
 
-        emitArgsParser(poetWriter, "safe_args", "SafeArgs", safeArgs());
-        emitArgsParser(poetWriter, "unsafe_args", "UnsafeArgs", unsafeArgs());
-
+        poetWriter.increaseIndent();
+        for (PythonField field : args()) {
+            String attribute = PythonIdentifierSanitizer.sanitize(field.attributeName());
+            poetWriter.writeIndentedLine(String.format("self.%s = %s", attribute, attribute));
+        }
+        poetWriter.writeIndentedLine("self.error_instance_id = error_instance_id if error_instance_id is not None "
+                + "else str(uuid.uuid4())");
+        poetWriter.writeIndentedLine("super().__init__(self.ERROR_NAME)");
         poetWriter.decreaseIndent();
         poetWriter.writeLine();
     }
 
-    default void emitArgsParser(
-            PythonPoetWriter poetWriter, String fieldName, String typeName, List<PythonField> fields) {
-        if (fields.isEmpty()) {
-            return;
-        }
-        poetWriter.writeIndentedLine(String.format("self.%s: %s.%s = {", fieldName, className(), typeName));
+    default void emitEncode(PythonPoetWriter poetWriter) {
+        poetWriter.writeIndentedLine("def encode(self) -> Dict[str, Any]:");
         poetWriter.increaseIndent();
-        for (int i = 0; i < fields.size(); i++) {
-            PythonField field = fields.get(i);
-            String comma = i == fields.size() - 1 ? "" : ",";
-            String lookup = field.isOptional()
-                    ? String.format("base_error.parameters.get('%s')", field.jsonIdentifier())
-                    : String.format("base_error.parameters['%s']", field.jsonIdentifier());
+        poetWriter.writeIndentedLine("return {");
+        poetWriter.increaseIndent();
+        poetWriter.writeIndentedLine("'errorCode': self.ERROR_CODE,");
+        poetWriter.writeIndentedLine("'errorName': self.ERROR_NAME,");
+        poetWriter.writeIndentedLine("'errorInstanceId': self.error_instance_id,");
+        poetWriter.writeIndentedLine("'parameters': {");
+        poetWriter.increaseIndent();
+        List<PythonField> args = args();
+        for (int i = 0; i < args.size(); i++) {
+            PythonField field = args.get(i);
+            String comma = i == args.size() - 1 ? "" : ",";
             poetWriter.writeIndentedLine(String.format(
-                    "'%s': %s%s", PythonIdentifierSanitizer.sanitize(field.attributeName()), lookup, comma));
+                    "'%s': ConjureEncoder.do_encode(self.%s)%s",
+                    field.jsonIdentifier(), PythonIdentifierSanitizer.sanitize(field.attributeName()), comma));
         }
         poetWriter.decreaseIndent();
         poetWriter.writeIndentedLine("}");
-    }
-
-    default void emitIsInstanceMethod(PythonPoetWriter poetWriter) {
-        poetWriter.writeIndentedLine("@builtins.classmethod");
-        poetWriter.writeIndentedLine("def is_instance(cls, error: ConjureHTTPError) -> bool:");
-        poetWriter.increaseIndent();
-        poetWriter.writeIndentedLine("return error.error_name == cls.ERROR_NAME");
+        poetWriter.decreaseIndent();
+        poetWriter.writeIndentedLine("}");
         poetWriter.decreaseIndent();
         poetWriter.writeLine();
     }
 
-    default void emitFromErrorMethod(PythonPoetWriter poetWriter) {
+    default void emitDecode(PythonPoetWriter poetWriter) {
         poetWriter.writeIndentedLine("@builtins.classmethod");
+        poetWriter.writeIndentedLine(String.format("def decode(cls, error: Dict[str, Any]) -> '%s':", className()));
+        poetWriter.increaseIndent();
+        poetWriter.writeIndentedLine("if error.get('errorName') != cls.ERROR_NAME:");
+        poetWriter.increaseIndent();
         poetWriter.writeIndentedLine(
-                String.format("def from_error(cls, error: ConjureHTTPError) -> '%s':", className()));
-        poetWriter.increaseIndent();
-        poetWriter.writeIndentedLine("if not cls.is_instance(error):");
-        poetWriter.increaseIndent();
-        poetWriter.writeIndentedLine("raise ValueError(f\"Error '{error.error_name}' is not a {cls.ERROR_NAME}\")");
+                "raise ValueError(f\"Error '{error.get('errorName')}' is not a {cls.ERROR_NAME}\")");
         poetWriter.decreaseIndent();
-        poetWriter.writeIndentedLine("return cls(error)");
+
+        List<PythonField> args = args();
+        if (!args.isEmpty()) {
+            poetWriter.writeIndentedLine("decoder = ConjureDecoder()");
+            poetWriter.writeIndentedLine("parameters = error.get('parameters', {})");
+        }
+
+        poetWriter.writeIndentedLine("return cls(");
+        poetWriter.increaseIndent();
+        for (PythonField field : args) {
+            poetWriter.writeIndentedLine(String.format(
+                    "%s=decoder.decode(parameters.get('%s'), %s),",
+                    PythonIdentifierSanitizer.sanitize(field.attributeName()),
+                    field.jsonIdentifier(),
+                    field.pythonType()));
+        }
+        poetWriter.writeIndentedLine("error_instance_id=error.get('errorInstanceId')");
+        poetWriter.decreaseIndent();
+        poetWriter.writeIndentedLine(")");
         poetWriter.decreaseIndent();
     }
 

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/ErrorSnippet.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/ErrorSnippet.java
@@ -17,6 +17,7 @@
 package com.palantir.conjure.python.poet;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.palantir.conjure.python.processors.PythonIdentifierSanitizer;
 import com.palantir.conjure.python.types.ImportTypeVisitor;
 import com.palantir.conjure.spec.Documentation;
@@ -40,6 +41,8 @@ public interface ErrorSnippet extends PythonSnippet {
                     .addNamedImports(NamedImport.of("Dict"))
                     .addNamedImports(NamedImport.of("Optional"))
                     .build());
+    ImmutableSet<String> PROTECTED_FIELDS =
+            ImmutableSet.of("add_note", "args", "decode", "encode", "error_instance_id", "with_traceback");
 
     @Override
     @Value.Default
@@ -101,15 +104,14 @@ public interface ErrorSnippet extends PythonSnippet {
     default void emitConstructor(PythonPoetWriter poetWriter) {
         StringBuilder signature = new StringBuilder("def __init__(self");
         for (PythonField field : args()) {
-            signature.append(String.format(
-                    ", %s: %s", PythonIdentifierSanitizer.sanitize(field.attributeName()), field.myPyType()));
+            signature.append(String.format(", %s: %s", argName(field), field.myPyType()));
         }
         signature.append(", error_instance_id: Optional[str] = None) -> None:");
         poetWriter.writeIndentedLine(signature.toString());
 
         poetWriter.increaseIndent();
         for (PythonField field : args()) {
-            String attribute = PythonIdentifierSanitizer.sanitize(field.attributeName());
+            String attribute = argName(field);
             poetWriter.writeIndentedLine(String.format("self._%s = %s", attribute, attribute));
         }
         poetWriter.writeIndentedLine("self.error_instance_id = error_instance_id if error_instance_id is not None "
@@ -121,7 +123,7 @@ public interface ErrorSnippet extends PythonSnippet {
 
     default void emitProperties(PythonPoetWriter poetWriter) {
         for (PythonField field : args()) {
-            String attribute = PythonIdentifierSanitizer.sanitize(field.attributeName());
+            String attribute = argName(field);
             poetWriter.writeIndentedLine("@builtins.property");
             poetWriter.writeIndentedLine(String.format("def %s(self) -> %s:", attribute, field.myPyType()));
             poetWriter.increaseIndent();
@@ -146,8 +148,7 @@ public interface ErrorSnippet extends PythonSnippet {
             PythonField field = args.get(i);
             String comma = i == args.size() - 1 ? "" : ",";
             poetWriter.writeIndentedLine(String.format(
-                    "'%s': ConjureEncoder.do_encode(self.%s)%s",
-                    field.jsonIdentifier(), PythonIdentifierSanitizer.sanitize(field.attributeName()), comma));
+                    "'%s': ConjureEncoder.do_encode(self.%s)%s", field.jsonIdentifier(), argName(field), comma));
         }
         poetWriter.decreaseIndent();
         poetWriter.writeIndentedLine("}");
@@ -178,14 +179,16 @@ public interface ErrorSnippet extends PythonSnippet {
         for (PythonField field : args) {
             poetWriter.writeIndentedLine(String.format(
                     "%s=decoder.decode(parameters.get('%s'), %s),",
-                    PythonIdentifierSanitizer.sanitize(field.attributeName()),
-                    field.jsonIdentifier(),
-                    field.pythonType()));
+                    argName(field), field.jsonIdentifier(), field.pythonType()));
         }
         poetWriter.writeIndentedLine("error_instance_id=error.get('errorInstanceId')");
         poetWriter.decreaseIndent();
         poetWriter.writeIndentedLine(")");
         poetWriter.decreaseIndent();
+    }
+
+    static String argName(PythonField field) {
+        return PythonIdentifierSanitizer.sanitize(field.attributeName(), PROTECTED_FIELDS);
     }
 
     class Builder extends ImmutableErrorSnippet.Builder {}

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/types/PythonErrorGenerator.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/types/PythonErrorGenerator.java
@@ -24,11 +24,13 @@ import com.palantir.conjure.python.poet.PythonPackage;
 import com.palantir.conjure.python.processors.packagename.PackageNameProcessor;
 import com.palantir.conjure.python.processors.typename.TypeNameProcessor;
 import com.palantir.conjure.spec.ErrorDefinition;
+import com.palantir.conjure.spec.FieldDefinition;
 import com.palantir.conjure.visitor.DealiasingTypeVisitor;
 import com.palantir.conjure.visitor.TypeVisitor;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public final class PythonErrorGenerator {
 
@@ -59,41 +61,12 @@ public final class PythonErrorGenerator {
         ImportTypeVisitor importVisitor =
                 new ImportTypeVisitor(errorDef.getErrorName(), implTypeNameProcessor, implPackageNameProcessor);
 
-        // Collect imports from all field types
-        Set<PythonImport> imports = errorDef.getSafeArgs().stream()
+        Set<PythonImport> imports = Stream.concat(errorDef.getSafeArgs().stream(), errorDef.getUnsafeArgs().stream())
                 .flatMap(entry -> entry.getType().accept(importVisitor).stream())
                 .collect(Collectors.toSet());
-        imports.addAll(errorDef.getUnsafeArgs().stream()
-                .flatMap(entry -> entry.getType().accept(importVisitor).stream())
-                .collect(Collectors.toSet()));
 
-        // Convert safe args to PythonFields
-        List<PythonField> safeArgs = errorDef.getSafeArgs().stream()
-                .map(entry -> PythonField.builder()
-                        .attributeName(CaseConverter.toCase(entry.getFieldName().get(), CaseConverter.Case.SNAKE_CASE))
-                        .jsonIdentifier(entry.getFieldName().get())
-                        .docs(entry.getDocs())
-                        .pythonType(entry.getType().accept(pythonTypeNameVisitor))
-                        .myPyType(entry.getType().accept(myPyTypeNameVisitor))
-                        .isOptional(dealiasingTypeVisitor
-                                .dealias(entry.getType())
-                                .fold(_typeDefinition -> false, type -> type.accept(TypeVisitor.IS_OPTIONAL)))
-                        .build())
-                .collect(Collectors.toList());
-
-        // Convert unsafe args to PythonFields
-        List<PythonField> unsafeArgs = errorDef.getUnsafeArgs().stream()
-                .map(entry -> PythonField.builder()
-                        .attributeName(CaseConverter.toCase(entry.getFieldName().get(), CaseConverter.Case.SNAKE_CASE))
-                        .jsonIdentifier(entry.getFieldName().get())
-                        .docs(entry.getDocs())
-                        .pythonType(entry.getType().accept(pythonTypeNameVisitor))
-                        .myPyType(entry.getType().accept(myPyTypeNameVisitor))
-                        .isOptional(dealiasingTypeVisitor
-                                .dealias(entry.getType())
-                                .fold(_typeDefinition -> false, type -> type.accept(TypeVisitor.IS_OPTIONAL)))
-                        .build())
-                .collect(Collectors.toList());
+        List<PythonField> safeArgs = toPythonFields(errorDef.getSafeArgs());
+        List<PythonField> unsafeArgs = toPythonFields(errorDef.getUnsafeArgs());
 
         return ErrorSnippet.builder()
                 .pythonPackage(PythonPackage.of(
@@ -110,5 +83,20 @@ public final class PythonErrorGenerator {
                 .safeArgs(safeArgs)
                 .unsafeArgs(unsafeArgs)
                 .build();
+    }
+
+    private List<PythonField> toPythonFields(List<FieldDefinition> fields) {
+        return fields.stream()
+                .map(entry -> PythonField.builder()
+                        .attributeName(CaseConverter.toCase(entry.getFieldName().get(), CaseConverter.Case.SNAKE_CASE))
+                        .jsonIdentifier(entry.getFieldName().get())
+                        .docs(entry.getDocs())
+                        .pythonType(entry.getType().accept(pythonTypeNameVisitor))
+                        .myPyType(entry.getType().accept(myPyTypeNameVisitor))
+                        .isOptional(dealiasingTypeVisitor
+                                .dealias(entry.getType())
+                                .fold(_typeDefinition -> false, type -> type.accept(TypeVisitor.IS_OPTIONAL)))
+                        .build())
+                .collect(Collectors.toList());
     }
 }

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/types/PythonErrorGenerator.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/types/PythonErrorGenerator.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/types/PythonErrorGenerator.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/types/PythonErrorGenerator.java
@@ -1,0 +1,114 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.python.types;
+
+import com.palantir.conjure.CaseConverter;
+import com.palantir.conjure.python.poet.ErrorSnippet;
+import com.palantir.conjure.python.poet.PythonField;
+import com.palantir.conjure.python.poet.PythonImport;
+import com.palantir.conjure.python.poet.PythonPackage;
+import com.palantir.conjure.python.processors.packagename.PackageNameProcessor;
+import com.palantir.conjure.python.processors.typename.TypeNameProcessor;
+import com.palantir.conjure.spec.ErrorDefinition;
+import com.palantir.conjure.visitor.DealiasingTypeVisitor;
+import com.palantir.conjure.visitor.TypeVisitor;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public final class PythonErrorGenerator {
+
+    private final PackageNameProcessor implPackageNameProcessor;
+    private final TypeNameProcessor implTypeNameProcessor;
+    private final PackageNameProcessor definitionPackageNameProcessor;
+    private final TypeNameProcessor definitionTypeNameProcessor;
+    private final DealiasingTypeVisitor dealiasingTypeVisitor;
+    private final PythonTypeNameVisitor pythonTypeNameVisitor;
+    private final MyPyTypeNameVisitor myPyTypeNameVisitor;
+
+    public PythonErrorGenerator(
+            PackageNameProcessor implPackageNameProcessor,
+            TypeNameProcessor implTypeNameProcessor,
+            PackageNameProcessor definitionPackageNameProcessor,
+            TypeNameProcessor definitionTypeNameProcessor,
+            DealiasingTypeVisitor dealiasingTypeVisitor) {
+        this.implPackageNameProcessor = implPackageNameProcessor;
+        this.implTypeNameProcessor = implTypeNameProcessor;
+        this.definitionPackageNameProcessor = definitionPackageNameProcessor;
+        this.definitionTypeNameProcessor = definitionTypeNameProcessor;
+        this.dealiasingTypeVisitor = dealiasingTypeVisitor;
+        this.pythonTypeNameVisitor = new PythonTypeNameVisitor(implTypeNameProcessor);
+        this.myPyTypeNameVisitor = new MyPyTypeNameVisitor(dealiasingTypeVisitor, implTypeNameProcessor);
+    }
+
+    public ErrorSnippet generateError(ErrorDefinition errorDef) {
+        ImportTypeVisitor importVisitor =
+                new ImportTypeVisitor(errorDef.getErrorName(), implTypeNameProcessor, implPackageNameProcessor);
+
+        // Collect imports from all field types
+        Set<PythonImport> imports = errorDef.getSafeArgs().stream()
+                .flatMap(entry -> entry.getType().accept(importVisitor).stream())
+                .collect(Collectors.toSet());
+        imports.addAll(errorDef.getUnsafeArgs().stream()
+                .flatMap(entry -> entry.getType().accept(importVisitor).stream())
+                .collect(Collectors.toSet()));
+
+        // Convert safe args to PythonFields
+        List<PythonField> safeArgs = errorDef.getSafeArgs().stream()
+                .map(entry -> PythonField.builder()
+                        .attributeName(CaseConverter.toCase(entry.getFieldName().get(), CaseConverter.Case.SNAKE_CASE))
+                        .jsonIdentifier(entry.getFieldName().get())
+                        .docs(entry.getDocs())
+                        .pythonType(entry.getType().accept(pythonTypeNameVisitor))
+                        .myPyType(entry.getType().accept(myPyTypeNameVisitor))
+                        .isOptional(dealiasingTypeVisitor
+                                .dealias(entry.getType())
+                                .fold(_typeDefinition -> false, type -> type.accept(TypeVisitor.IS_OPTIONAL)))
+                        .build())
+                .collect(Collectors.toList());
+
+        // Convert unsafe args to PythonFields
+        List<PythonField> unsafeArgs = errorDef.getUnsafeArgs().stream()
+                .map(entry -> PythonField.builder()
+                        .attributeName(CaseConverter.toCase(entry.getFieldName().get(), CaseConverter.Case.SNAKE_CASE))
+                        .jsonIdentifier(entry.getFieldName().get())
+                        .docs(entry.getDocs())
+                        .pythonType(entry.getType().accept(pythonTypeNameVisitor))
+                        .myPyType(entry.getType().accept(myPyTypeNameVisitor))
+                        .isOptional(dealiasingTypeVisitor
+                                .dealias(entry.getType())
+                                .fold(_typeDefinition -> false, type -> type.accept(TypeVisitor.IS_OPTIONAL)))
+                        .build())
+                .collect(Collectors.toList());
+
+        return ErrorSnippet.builder()
+                .pythonPackage(PythonPackage.of(
+                        implPackageNameProcessor.process(errorDef.getErrorName().getPackage())))
+                .className(implTypeNameProcessor.process(errorDef.getErrorName()))
+                .definitionPackage(PythonPackage.of(definitionPackageNameProcessor.process(
+                        errorDef.getErrorName().getPackage())))
+                .definitionName(definitionTypeNameProcessor.process(errorDef.getErrorName()))
+                .addAllImports(ErrorSnippet.DEFAULT_IMPORTS)
+                .addAllImports(imports)
+                .docs(errorDef.getDocs())
+                .errorCode(errorDef.getCode().toString())
+                .namespace(errorDef.getNamespace().toString())
+                .safeArgs(safeArgs)
+                .unsafeArgs(unsafeArgs)
+                .build();
+    }
+}

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/types/PythonErrorGenerator.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/types/PythonErrorGenerator.java
@@ -16,7 +16,6 @@
 
 package com.palantir.conjure.python.types;
 
-import com.palantir.conjure.CaseConverter;
 import com.palantir.conjure.python.poet.ErrorSnippet;
 import com.palantir.conjure.python.poet.PythonField;
 import com.palantir.conjure.python.poet.PythonImport;
@@ -26,7 +25,6 @@ import com.palantir.conjure.python.processors.typename.TypeNameProcessor;
 import com.palantir.conjure.spec.ErrorDefinition;
 import com.palantir.conjure.spec.FieldDefinition;
 import com.palantir.conjure.visitor.DealiasingTypeVisitor;
-import com.palantir.conjure.visitor.TypeVisitor;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -68,7 +66,7 @@ public final class PythonErrorGenerator {
         List<PythonField> safeArgs = toPythonFields(errorDef.getSafeArgs());
         List<PythonField> unsafeArgs = toPythonFields(errorDef.getUnsafeArgs());
 
-        return ErrorSnippet.builder()
+        ErrorSnippet.Builder builder = ErrorSnippet.builder()
                 .pythonPackage(PythonPackage.of(
                         implPackageNameProcessor.process(errorDef.getErrorName().getPackage())))
                 .className(implTypeNameProcessor.process(errorDef.getErrorName()))
@@ -81,22 +79,19 @@ public final class PythonErrorGenerator {
                 .errorCode(errorDef.getCode().toString())
                 .namespace(errorDef.getNamespace().toString())
                 .safeArgs(safeArgs)
-                .unsafeArgs(unsafeArgs)
-                .build();
+                .unsafeArgs(unsafeArgs);
+
+        if (!safeArgs.isEmpty() || !unsafeArgs.isEmpty()) {
+            builder.addImports(ErrorSnippet.TYPED_DICT_IMPORT);
+        }
+
+        return builder.build();
     }
 
     private List<PythonField> toPythonFields(List<FieldDefinition> fields) {
         return fields.stream()
-                .map(entry -> PythonField.builder()
-                        .attributeName(CaseConverter.toCase(entry.getFieldName().get(), CaseConverter.Case.SNAKE_CASE))
-                        .jsonIdentifier(entry.getFieldName().get())
-                        .docs(entry.getDocs())
-                        .pythonType(entry.getType().accept(pythonTypeNameVisitor))
-                        .myPyType(entry.getType().accept(myPyTypeNameVisitor))
-                        .isOptional(dealiasingTypeVisitor
-                                .dealias(entry.getType())
-                                .fold(_typeDefinition -> false, type -> type.accept(TypeVisitor.IS_OPTIONAL)))
-                        .build())
+                .map(field -> PythonTypeGenerator.generateField(
+                        field, pythonTypeNameVisitor, myPyTypeNameVisitor, dealiasingTypeVisitor))
                 .collect(Collectors.toList());
     }
 }

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/types/PythonErrorGenerator.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/types/PythonErrorGenerator.java
@@ -66,7 +66,7 @@ public final class PythonErrorGenerator {
         List<PythonField> safeArgs = toPythonFields(errorDef.getSafeArgs());
         List<PythonField> unsafeArgs = toPythonFields(errorDef.getUnsafeArgs());
 
-        ErrorSnippet.Builder builder = ErrorSnippet.builder()
+        return ErrorSnippet.builder()
                 .pythonPackage(PythonPackage.of(
                         implPackageNameProcessor.process(errorDef.getErrorName().getPackage())))
                 .className(implTypeNameProcessor.process(errorDef.getErrorName()))
@@ -79,13 +79,8 @@ public final class PythonErrorGenerator {
                 .errorCode(errorDef.getCode().toString())
                 .namespace(errorDef.getNamespace().toString())
                 .safeArgs(safeArgs)
-                .unsafeArgs(unsafeArgs);
-
-        if (!safeArgs.isEmpty() || !unsafeArgs.isEmpty()) {
-            builder.addImports(ErrorSnippet.TYPED_DICT_IMPORT);
-        }
-
-        return builder.build();
+                .unsafeArgs(unsafeArgs)
+                .build();
     }
 
     private List<PythonField> toPythonFields(List<FieldDefinition> fields) {

--- a/conjure-python-core/src/main/java/com/palantir/conjure/python/types/PythonTypeGenerator.java
+++ b/conjure-python-core/src/main/java/com/palantir/conjure/python/types/PythonTypeGenerator.java
@@ -31,6 +31,7 @@ import com.palantir.conjure.python.processors.packagename.PackageNameProcessor;
 import com.palantir.conjure.python.processors.typename.TypeNameProcessor;
 import com.palantir.conjure.spec.AliasDefinition;
 import com.palantir.conjure.spec.EnumDefinition;
+import com.palantir.conjure.spec.FieldDefinition;
 import com.palantir.conjure.spec.ObjectDefinition;
 import com.palantir.conjure.spec.Type;
 import com.palantir.conjure.spec.TypeDefinition;
@@ -95,6 +96,23 @@ public final class PythonTypeGenerator {
         });
     }
 
+    static PythonField generateField(
+            FieldDefinition field,
+            PythonTypeNameVisitor pythonTypeNameVisitor,
+            MyPyTypeNameVisitor myPyTypeNameVisitor,
+            DealiasingTypeVisitor dealiasingTypeVisitor) {
+        return PythonField.builder()
+                .attributeName(CaseConverter.toCase(field.getFieldName().get(), CaseConverter.Case.SNAKE_CASE))
+                .jsonIdentifier(field.getFieldName().get())
+                .docs(field.getDocs())
+                .pythonType(field.getType().accept(pythonTypeNameVisitor))
+                .myPyType(field.getType().accept(myPyTypeNameVisitor))
+                .isOptional(dealiasingTypeVisitor
+                        .dealias(field.getType())
+                        .fold(_typeDefinition -> false, type -> type.accept(TypeVisitor.IS_OPTIONAL)))
+                .build();
+    }
+
     private BeanSnippet generateBean(ObjectDefinition typeDef) {
         ImportTypeVisitor importVisitor =
                 new ImportTypeVisitor(typeDef.getTypeName(), implTypeNameProcessor, implPackageNameProcessor);
@@ -104,16 +122,7 @@ public final class PythonTypeGenerator {
                 .collect(Collectors.toSet());
 
         List<PythonField> fields = typeDef.getFields().stream()
-                .map(entry -> PythonField.builder()
-                        .attributeName(CaseConverter.toCase(entry.getFieldName().get(), CaseConverter.Case.SNAKE_CASE))
-                        .jsonIdentifier(entry.getFieldName().get())
-                        .docs(entry.getDocs())
-                        .pythonType(entry.getType().accept(pythonTypeNameVisitor))
-                        .myPyType(entry.getType().accept(myPyTypeNameVisitor))
-                        .isOptional(dealiasingTypeVisitor
-                                .dealias(entry.getType())
-                                .fold(_typeDefinition -> false, type -> type.accept(TypeVisitor.IS_OPTIONAL)))
-                        .build())
+                .map(entry -> generateField(entry, pythonTypeNameVisitor, myPyTypeNameVisitor, dealiasingTypeVisitor))
                 .collect(Collectors.toList());
 
         return BeanSnippet.builder()

--- a/conjure-python-core/src/test/java/com/palantir/conjure/python/ConjurePythonGeneratorTest.java
+++ b/conjure-python-core/src/test/java/com/palantir/conjure/python/ConjurePythonGeneratorTest.java
@@ -44,6 +44,7 @@ public final class ConjurePythonGeneratorTest {
             .generatorVersion("0.0.0")
             .shouldWriteCondaRecipe(true)
             .generateRawSource(false)
+            .generateErrorTypes(true)
             .build());
     private final InMemoryPythonFileWriter pythonFileWriter = new InMemoryPythonFileWriter();
 

--- a/conjure-python-core/src/test/java/com/palantir/conjure/python/poet/ErrorSnippetTest.java
+++ b/conjure-python-core/src/test/java/com/palantir/conjure/python/poet/ErrorSnippetTest.java
@@ -1,0 +1,60 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.python.poet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.Test;
+
+public final class ErrorSnippetTest {
+    @Test
+    public void sanitizesProtectedFields() {
+        ImmutableList<String> protectedFields =
+                ImmutableList.of("add_note", "args", "decode", "encode", "error_instance_id", "with_traceback");
+
+        ErrorSnippet.Builder snippet = ErrorSnippet.builder()
+                .className("TestError")
+                .definitionName("TestError")
+                .definitionPackage(PythonPackage.of("test"))
+                .pythonPackage(PythonPackage.of("test"))
+                .errorCode("INVALID_ARGUMENT")
+                .namespace("Test");
+        protectedFields.forEach(field -> snippet.addSafeArgs(PythonField.builder()
+                .attributeName(field)
+                .jsonIdentifier(field)
+                .pythonType("str")
+                .myPyType("str")
+                .isOptional(false)
+                .build()));
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        snippet.build().emit(new PythonPoetWriter(new PrintStream(output)));
+        String generated = output.toString(StandardCharsets.UTF_8);
+
+        protectedFields.forEach(field -> {
+            assertThat(generated).contains(field + "_: str");
+            assertThat(generated).contains("self._" + field + "_ = " + field + "_");
+            assertThat(generated).contains("def " + field + "_(self) -> str:");
+            assertThat(generated).contains("ConjureEncoder.do_encode(self." + field + "_)");
+            assertThat(generated).contains(field + "_=decoder.decode(");
+        });
+    }
+}

--- a/conjure-python-core/src/test/resources/errors/example-errors.yml
+++ b/conjure-python-core/src/test/resources/errors/example-errors.yml
@@ -1,0 +1,38 @@
+types:
+  definitions:
+    default-package: com.palantir.product
+    objects:
+      Recipe:
+        fields:
+          name: string
+          ingredients: list<string>
+    errors:
+      CategoryNotFound:
+        namespace: Recipe
+        code: NOT_FOUND
+        safe-args:
+          categoryId: string
+          availableCategories: list<string>
+        docs: Thrown when the requested recipe category doesn't exist
+
+      InvalidIngredient:
+        namespace: Recipe
+        code: INVALID_ARGUMENT
+        safe-args:
+          ingredientName: string
+        unsafe-args:
+          userId: string
+        docs: Thrown when an ingredient is invalid for the recipe
+
+services:
+  RecipeService:
+    name: Recipe Service
+    package: com.palantir.product
+    base-path: /recipes
+    endpoints:
+      getRecipesByCategory:
+        http: GET /category/{categoryId}
+        args:
+          categoryId: string
+        returns: list<Recipe>
+        docs: Get recipes by category

--- a/conjure-python-core/src/test/resources/errors/example-errors.yml
+++ b/conjure-python-core/src/test/resources/errors/example-errors.yml
@@ -27,6 +27,14 @@ types:
           userId: string
         docs: Thrown when a file system identifier is invalid
 
+      ContextWindowExceeded:
+        namespace: MioMl
+        code: INVALID_ARGUMENT
+        safe-args:
+          inputTokenCount: integer
+          maxTokens: integer
+        docs: The supplied input exceeded the model's maximum context window.
+
 services:
   DatasetService:
     name: Dataset Service

--- a/conjure-python-core/src/test/resources/errors/example-errors.yml
+++ b/conjure-python-core/src/test/resources/errors/example-errors.yml
@@ -27,14 +27,6 @@ types:
           userId: string
         docs: Thrown when a file system identifier is invalid
 
-      ContextWindowExceeded:
-        namespace: Datasets
-        code: INVALID_ARGUMENT
-        safe-args:
-          inputTokenCount: integer
-          maxTokens: integer
-        docs: The supplied input exceeded the model's maximum context window.
-
 services:
   DatasetService:
     name: Dataset Service

--- a/conjure-python-core/src/test/resources/errors/example-errors.yml
+++ b/conjure-python-core/src/test/resources/errors/example-errors.yml
@@ -2,37 +2,37 @@ types:
   definitions:
     default-package: com.palantir.product
     objects:
-      Recipe:
+      Dataset:
         fields:
-          name: string
-          ingredients: list<string>
+          fileSystemId: string
+          rid: string
     errors:
-      CategoryNotFound:
-        namespace: Recipe
+      DatasetNotFound:
+        namespace: Datasets
         code: NOT_FOUND
         safe-args:
-          categoryId: string
-          availableCategories: list<string>
-        docs: Thrown when the requested recipe category doesn't exist
+          datasetRid: string
+          availableDatasets: list<string>
+        docs: Thrown when the requested dataset does not exist
 
-      InvalidIngredient:
-        namespace: Recipe
+      InvalidFileSystemId:
+        namespace: Datasets
         code: INVALID_ARGUMENT
         safe-args:
-          ingredientName: string
+          fileSystemId: string
         unsafe-args:
           userId: string
-        docs: Thrown when an ingredient is invalid for the recipe
+        docs: Thrown when a file system identifier is invalid
 
 services:
-  RecipeService:
-    name: Recipe Service
+  DatasetService:
+    name: Dataset Service
     package: com.palantir.product
-    base-path: /recipes
+    base-path: /datasets
     endpoints:
-      getRecipesByCategory:
-        http: GET /category/{categoryId}
+      getDatasetsByFileSystem:
+        http: GET /fileSystem/{fileSystemId}
         args:
-          categoryId: string
-        returns: list<Recipe>
-        docs: Get recipes by category
+          fileSystemId: string
+        returns: list<Dataset>
+        docs: Get datasets by file system

--- a/conjure-python-core/src/test/resources/errors/example-errors.yml
+++ b/conjure-python-core/src/test/resources/errors/example-errors.yml
@@ -20,6 +20,7 @@ types:
         code: INVALID_ARGUMENT
         safe-args:
           fileSystemId: string
+          reason: optional<string>
         unsafe-args:
           userId: string
         docs: Thrown when a file system identifier is invalid

--- a/conjure-python-core/src/test/resources/errors/example-errors.yml
+++ b/conjure-python-core/src/test/resources/errors/example-errors.yml
@@ -28,7 +28,7 @@ types:
         docs: Thrown when a file system identifier is invalid
 
       ContextWindowExceeded:
-        namespace: MioMl
+        namespace: Datasets
         code: INVALID_ARGUMENT
         safe-args:
           inputTokenCount: integer

--- a/conjure-python-core/src/test/resources/errors/example-errors.yml
+++ b/conjure-python-core/src/test/resources/errors/example-errors.yml
@@ -11,7 +11,9 @@ types:
         namespace: Datasets
         code: NOT_FOUND
         safe-args:
-          datasetRid: string
+          datasetRid:
+            type: string
+            docs: The resource identifier of the dataset that was requested.
           availableDatasets: list<string>
         docs: Thrown when the requested dataset does not exist
 

--- a/conjure-python-core/src/test/resources/errors/expected/conda_recipe/meta.yaml
+++ b/conjure-python-core/src/test/resources/errors/expected/conda_recipe/meta.yaml
@@ -1,0 +1,23 @@
+# coding=utf-8
+package:
+    name: package-name
+    version: 0.0.0
+
+source:
+    path: ../
+
+build:
+    noarch: python
+    script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+    build:
+        - python
+        - setuptools
+        - requests
+        - conjure-python-client >=2.8.0,<4
+
+    run:
+        - python
+        - requests
+        - conjure-python-client >=2.8.0,<4

--- a/conjure-python-core/src/test/resources/errors/expected/package_name/__init__.py
+++ b/conjure-python-core/src/test/resources/errors/expected/package_name/__init__.py
@@ -1,0 +1,9 @@
+# coding=utf-8
+__all__ = [
+    'product',
+]
+
+__conjure_generator_version__ = "0.0.0"
+
+__version__ = "0.0.0"
+

--- a/conjure-python-core/src/test/resources/errors/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/errors/expected/package_name/_impl.py
@@ -27,8 +27,8 @@ class product_ContextWindowExceeded(Exception):
     """
 
     ERROR_CODE = "INVALID_ARGUMENT"
-    ERROR_NAMESPACE = "MioMl"
-    ERROR_NAME = "MioMl:ContextWindowExceeded"
+    ERROR_NAMESPACE = "Datasets"
+    ERROR_NAME = "Datasets:ContextWindowExceeded"
 
     def __init__(self, input_token_count: int, max_tokens: int, error_instance_id: Optional[str] = None) -> None:
         self.input_token_count = input_token_count

--- a/conjure-python-core/src/test/resources/errors/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/errors/expected/package_name/_impl.py
@@ -79,10 +79,7 @@ class product_DatasetNotFound(ConjureHTTPError):
 
     @builtins.classmethod
     def is_instance(cls, error: ConjureHTTPError) -> bool:
-        return (
-            error.error_name == cls.ERROR_NAME and
-            error.error_code == cls.ERROR_CODE
-        )
+        return error.error_name == cls.ERROR_NAME
 
     @builtins.classmethod
     def from_error(cls, error: ConjureHTTPError) -> 'product_DatasetNotFound':
@@ -168,10 +165,7 @@ class product_InvalidFileSystemId(ConjureHTTPError):
 
     @builtins.classmethod
     def is_instance(cls, error: ConjureHTTPError) -> bool:
-        return (
-            error.error_name == cls.ERROR_NAME and
-            error.error_code == cls.ERROR_CODE
-        )
+        return error.error_name == cls.ERROR_NAME
 
     @builtins.classmethod
     def from_error(cls, error: ConjureHTTPError) -> 'product_InvalidFileSystemId':

--- a/conjure-python-core/src/test/resources/errors/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/errors/expected/package_name/_impl.py
@@ -6,6 +6,7 @@ from conjure_python_client import (
     ConjureEncoder,
     ConjureFieldDefinition,
     ConjureHTTPError,
+    OptionalTypeWrapper,
     Service,
 )
 from requests.adapters import (
@@ -15,6 +16,7 @@ from typing import (
     Any,
     Dict,
     List,
+    Optional,
     TypedDict,
 )
 from urllib.parse import (
@@ -56,7 +58,7 @@ class product_DatasetNotFound(ConjureHTTPError):
 
     ERROR_CODE = "NOT_FOUND"
     ERROR_NAMESPACE = "Datasets"
-    ERROR_NAME = "DatasetNotFound"
+    ERROR_NAME = "Datasets:DatasetNotFound"
 
     class SafeArgs(TypedDict):
         dataset_rid: str
@@ -75,17 +77,17 @@ class product_DatasetNotFound(ConjureHTTPError):
             'available_datasets': base_error.parameters['availableDatasets']
         }
 
-    @classmethod
+    @builtins.classmethod
     def is_instance(cls, error: ConjureHTTPError) -> bool:
         return (
             error.error_name == cls.ERROR_NAME and
             error.error_code == cls.ERROR_CODE
         )
 
-    @classmethod
+    @builtins.classmethod
     def from_error(cls, error: ConjureHTTPError) -> 'product_DatasetNotFound':
         if not cls.is_instance(error):
-            raise ValueError(f"Error is not a {cls.ERROR_NAME}")
+            raise ValueError(f"Error '{error.error_name}' is not a {cls.ERROR_NAME}")
         return cls(error)
 
 
@@ -139,10 +141,11 @@ class product_InvalidFileSystemId(ConjureHTTPError):
 
     ERROR_CODE = "INVALID_ARGUMENT"
     ERROR_NAMESPACE = "Datasets"
-    ERROR_NAME = "InvalidFileSystemId"
+    ERROR_NAME = "Datasets:InvalidFileSystemId"
 
     class SafeArgs(TypedDict):
         file_system_id: str
+        reason: Optional[str]
 
     class UnsafeArgs(TypedDict):
         user_id: str
@@ -156,23 +159,24 @@ class product_InvalidFileSystemId(ConjureHTTPError):
             parameters=base_error.parameters
         )
         self.safe_args: product_InvalidFileSystemId.SafeArgs = {
-            'file_system_id': base_error.parameters['fileSystemId']
+            'file_system_id': base_error.parameters['fileSystemId'],
+            'reason': base_error.parameters.get('reason')
         }
         self.unsafe_args: product_InvalidFileSystemId.UnsafeArgs = {
             'user_id': base_error.parameters['userId']
         }
 
-    @classmethod
+    @builtins.classmethod
     def is_instance(cls, error: ConjureHTTPError) -> bool:
         return (
             error.error_name == cls.ERROR_NAME and
             error.error_code == cls.ERROR_CODE
         )
 
-    @classmethod
+    @builtins.classmethod
     def from_error(cls, error: ConjureHTTPError) -> 'product_InvalidFileSystemId':
         if not cls.is_instance(error):
-            raise ValueError(f"Error is not a {cls.ERROR_NAME}")
+            raise ValueError(f"Error '{error.error_name}' is not a {cls.ERROR_NAME}")
         return cls(error)
 
 

--- a/conjure-python-core/src/test/resources/errors/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/errors/expected/package_name/_impl.py
@@ -5,7 +5,6 @@ from conjure_python_client import (
     ConjureDecoder,
     ConjureEncoder,
     ConjureFieldDefinition,
-    ConjureHTTPError,
     OptionalTypeWrapper,
     Service,
 )
@@ -17,11 +16,54 @@ from typing import (
     Dict,
     List,
     Optional,
-    TypedDict,
 )
 from urllib.parse import (
     quote,
 )
+import uuid
+
+class product_ContextWindowExceeded(Exception):
+    """The supplied input exceeded the model's maximum context window.
+    """
+
+    ERROR_CODE = "INVALID_ARGUMENT"
+    ERROR_NAMESPACE = "MioMl"
+    ERROR_NAME = "MioMl:ContextWindowExceeded"
+
+    def __init__(self, input_token_count: int, max_tokens: int, error_instance_id: Optional[str] = None) -> None:
+        self.input_token_count = input_token_count
+        self.max_tokens = max_tokens
+        self.error_instance_id = error_instance_id if error_instance_id is not None else str(uuid.uuid4())
+        super().__init__(self.ERROR_NAME)
+
+    def encode(self) -> Dict[str, Any]:
+        return {
+            'errorCode': self.ERROR_CODE,
+            'errorName': self.ERROR_NAME,
+            'errorInstanceId': self.error_instance_id,
+            'parameters': {
+                'inputTokenCount': ConjureEncoder.do_encode(self.input_token_count),
+                'maxTokens': ConjureEncoder.do_encode(self.max_tokens)
+            }
+        }
+
+    @builtins.classmethod
+    def decode(cls, error: Dict[str, Any]) -> 'product_ContextWindowExceeded':
+        if error.get('errorName') != cls.ERROR_NAME:
+            raise ValueError(f"Error '{error.get('errorName')}' is not a {cls.ERROR_NAME}")
+        decoder = ConjureDecoder()
+        parameters = error.get('parameters', {})
+        return cls(
+            input_token_count=decoder.decode(parameters.get('inputTokenCount'), int),
+            max_tokens=decoder.decode(parameters.get('maxTokens'), int),
+            error_instance_id=error.get('errorInstanceId')
+        )
+
+
+product_ContextWindowExceeded.__name__ = "ContextWindowExceeded"
+product_ContextWindowExceeded.__qualname__ = "ContextWindowExceeded"
+product_ContextWindowExceeded.__module__ = "package_name.product"
+
 
 class product_Dataset(ConjureBeanType):
 
@@ -52,7 +94,7 @@ product_Dataset.__qualname__ = "Dataset"
 product_Dataset.__module__ = "package_name.product"
 
 
-class product_DatasetNotFound(ConjureHTTPError):
+class product_DatasetNotFound(Exception):
     """Thrown when the requested dataset does not exist
     """
 
@@ -60,32 +102,34 @@ class product_DatasetNotFound(ConjureHTTPError):
     ERROR_NAMESPACE = "Datasets"
     ERROR_NAME = "Datasets:DatasetNotFound"
 
-    class SafeArgs(TypedDict):
-        dataset_rid: str
-        available_datasets: List[str]
+    def __init__(self, dataset_rid: str, available_datasets: List[str], error_instance_id: Optional[str] = None) -> None:
+        self.dataset_rid = dataset_rid
+        self.available_datasets = available_datasets
+        self.error_instance_id = error_instance_id if error_instance_id is not None else str(uuid.uuid4())
+        super().__init__(self.ERROR_NAME)
 
-    def __init__(self, base_error: ConjureHTTPError) -> None:
-        super().__init__(
-            status_code=base_error.status_code,
-            error_code=base_error.error_code,
-            error_name=base_error.error_name,
-            error_instance_id=base_error.error_instance_id,
-            parameters=base_error.parameters
-        )
-        self.safe_args: product_DatasetNotFound.SafeArgs = {
-            'dataset_rid': base_error.parameters['datasetRid'],
-            'available_datasets': base_error.parameters['availableDatasets']
+    def encode(self) -> Dict[str, Any]:
+        return {
+            'errorCode': self.ERROR_CODE,
+            'errorName': self.ERROR_NAME,
+            'errorInstanceId': self.error_instance_id,
+            'parameters': {
+                'datasetRid': ConjureEncoder.do_encode(self.dataset_rid),
+                'availableDatasets': ConjureEncoder.do_encode(self.available_datasets)
+            }
         }
 
     @builtins.classmethod
-    def is_instance(cls, error: ConjureHTTPError) -> bool:
-        return error.error_name == cls.ERROR_NAME
-
-    @builtins.classmethod
-    def from_error(cls, error: ConjureHTTPError) -> 'product_DatasetNotFound':
-        if not cls.is_instance(error):
-            raise ValueError(f"Error '{error.error_name}' is not a {cls.ERROR_NAME}")
-        return cls(error)
+    def decode(cls, error: Dict[str, Any]) -> 'product_DatasetNotFound':
+        if error.get('errorName') != cls.ERROR_NAME:
+            raise ValueError(f"Error '{error.get('errorName')}' is not a {cls.ERROR_NAME}")
+        decoder = ConjureDecoder()
+        parameters = error.get('parameters', {})
+        return cls(
+            dataset_rid=decoder.decode(parameters.get('datasetRid'), str),
+            available_datasets=decoder.decode(parameters.get('availableDatasets'), List[str]),
+            error_instance_id=error.get('errorInstanceId')
+        )
 
 
 product_DatasetNotFound.__name__ = "DatasetNotFound"
@@ -132,7 +176,7 @@ product_DatasetService.__qualname__ = "DatasetService"
 product_DatasetService.__module__ = "package_name.product"
 
 
-class product_InvalidFileSystemId(ConjureHTTPError):
+class product_InvalidFileSystemId(Exception):
     """Thrown when a file system identifier is invalid
     """
 
@@ -140,38 +184,37 @@ class product_InvalidFileSystemId(ConjureHTTPError):
     ERROR_NAMESPACE = "Datasets"
     ERROR_NAME = "Datasets:InvalidFileSystemId"
 
-    class SafeArgs(TypedDict):
-        file_system_id: str
-        reason: Optional[str]
+    def __init__(self, file_system_id: str, reason: Optional[str], user_id: str, error_instance_id: Optional[str] = None) -> None:
+        self.file_system_id = file_system_id
+        self.reason = reason
+        self.user_id = user_id
+        self.error_instance_id = error_instance_id if error_instance_id is not None else str(uuid.uuid4())
+        super().__init__(self.ERROR_NAME)
 
-    class UnsafeArgs(TypedDict):
-        user_id: str
+    def encode(self) -> Dict[str, Any]:
+        return {
+            'errorCode': self.ERROR_CODE,
+            'errorName': self.ERROR_NAME,
+            'errorInstanceId': self.error_instance_id,
+            'parameters': {
+                'fileSystemId': ConjureEncoder.do_encode(self.file_system_id),
+                'reason': ConjureEncoder.do_encode(self.reason),
+                'userId': ConjureEncoder.do_encode(self.user_id)
+            }
+        }
 
-    def __init__(self, base_error: ConjureHTTPError) -> None:
-        super().__init__(
-            status_code=base_error.status_code,
-            error_code=base_error.error_code,
-            error_name=base_error.error_name,
-            error_instance_id=base_error.error_instance_id,
-            parameters=base_error.parameters
+    @builtins.classmethod
+    def decode(cls, error: Dict[str, Any]) -> 'product_InvalidFileSystemId':
+        if error.get('errorName') != cls.ERROR_NAME:
+            raise ValueError(f"Error '{error.get('errorName')}' is not a {cls.ERROR_NAME}")
+        decoder = ConjureDecoder()
+        parameters = error.get('parameters', {})
+        return cls(
+            file_system_id=decoder.decode(parameters.get('fileSystemId'), str),
+            reason=decoder.decode(parameters.get('reason'), OptionalTypeWrapper[str]),
+            user_id=decoder.decode(parameters.get('userId'), str),
+            error_instance_id=error.get('errorInstanceId')
         )
-        self.safe_args: product_InvalidFileSystemId.SafeArgs = {
-            'file_system_id': base_error.parameters['fileSystemId'],
-            'reason': base_error.parameters.get('reason')
-        }
-        self.unsafe_args: product_InvalidFileSystemId.UnsafeArgs = {
-            'user_id': base_error.parameters['userId']
-        }
-
-    @builtins.classmethod
-    def is_instance(cls, error: ConjureHTTPError) -> bool:
-        return error.error_name == cls.ERROR_NAME
-
-    @builtins.classmethod
-    def from_error(cls, error: ConjureHTTPError) -> 'product_InvalidFileSystemId':
-        if not cls.is_instance(error):
-            raise ValueError(f"Error '{error.error_name}' is not a {cls.ERROR_NAME}")
-        return cls(error)
 
 
 product_InvalidFileSystemId.__name__ = "InvalidFileSystemId"

--- a/conjure-python-core/src/test/resources/errors/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/errors/expected/package_name/_impl.py
@@ -1,0 +1,187 @@
+# coding=utf-8
+import builtins
+from conjure_python_client import (
+    ConjureBeanType,
+    ConjureDecoder,
+    ConjureEncoder,
+    ConjureFieldDefinition,
+    ConjureHTTPError,
+    Service,
+)
+from requests.adapters import (
+    Response,
+)
+from typing import (
+    Any,
+    Dict,
+    List,
+    TypedDict,
+)
+from urllib.parse import (
+    quote,
+)
+
+class product_CategoryNotFound(ConjureHTTPError):
+    """Thrown when the requested recipe category doesn't exist
+    """
+
+    ERROR_CODE = "NOT_FOUND"
+    ERROR_NAMESPACE = "Recipe"
+    ERROR_NAME = "CategoryNotFound"
+
+    class SafeArgs(TypedDict):
+        category_id: str
+        available_categories: List[str]
+
+    def __init__(self, base_error: ConjureHTTPError) -> None:
+        super().__init__(
+            status_code=base_error.status_code,
+            error_code=base_error.error_code,
+            error_name=base_error.error_name,
+            error_instance_id=base_error.error_instance_id,
+            parameters=base_error.parameters
+        )
+        self.safe_args: product_CategoryNotFound.SafeArgs = {
+            'category_id': base_error.parameters['categoryId'],
+            'available_categories': base_error.parameters['availableCategories']
+        }
+
+    @classmethod
+    def is_instance(cls, error: ConjureHTTPError) -> bool:
+        """Check if a ConjureHTTPError is this specific error type"""
+        return (
+            error.error_name == cls.ERROR_NAME and
+            error.error_code == cls.ERROR_CODE
+        )
+
+    @classmethod
+    def from_error(cls, error: ConjureHTTPError) -> 'product_CategoryNotFound':
+        """Convert a generic ConjureHTTPError to this typed error"""
+        if not cls.is_instance(error):
+            raise ValueError(f"Error is not a {cls.ERROR_NAME}")
+        return cls(error)
+
+
+product_CategoryNotFound.__name__ = "CategoryNotFound"
+product_CategoryNotFound.__qualname__ = "CategoryNotFound"
+product_CategoryNotFound.__module__ = "package_name.product"
+
+
+class product_InvalidIngredient(ConjureHTTPError):
+    """Thrown when an ingredient is invalid for the recipe
+    """
+
+    ERROR_CODE = "INVALID_ARGUMENT"
+    ERROR_NAMESPACE = "Recipe"
+    ERROR_NAME = "InvalidIngredient"
+
+    class SafeArgs(TypedDict):
+        ingredient_name: str
+
+    class UnsafeArgs(TypedDict):
+        user_id: str
+
+    def __init__(self, base_error: ConjureHTTPError) -> None:
+        super().__init__(
+            status_code=base_error.status_code,
+            error_code=base_error.error_code,
+            error_name=base_error.error_name,
+            error_instance_id=base_error.error_instance_id,
+            parameters=base_error.parameters
+        )
+        self.safe_args: product_InvalidIngredient.SafeArgs = {
+            'ingredient_name': base_error.parameters['ingredientName']
+        }
+        self.unsafe_args: product_InvalidIngredient.UnsafeArgs = {
+            'user_id': base_error.parameters['userId']
+        }
+
+    @classmethod
+    def is_instance(cls, error: ConjureHTTPError) -> bool:
+        """Check if a ConjureHTTPError is this specific error type"""
+        return (
+            error.error_name == cls.ERROR_NAME and
+            error.error_code == cls.ERROR_CODE
+        )
+
+    @classmethod
+    def from_error(cls, error: ConjureHTTPError) -> 'product_InvalidIngredient':
+        """Convert a generic ConjureHTTPError to this typed error"""
+        if not cls.is_instance(error):
+            raise ValueError(f"Error is not a {cls.ERROR_NAME}")
+        return cls(error)
+
+
+product_InvalidIngredient.__name__ = "InvalidIngredient"
+product_InvalidIngredient.__qualname__ = "InvalidIngredient"
+product_InvalidIngredient.__module__ = "package_name.product"
+
+
+class product_Recipe(ConjureBeanType):
+
+    @builtins.classmethod
+    def _fields(cls) -> Dict[str, ConjureFieldDefinition]:
+        return {
+            'name': ConjureFieldDefinition('name', str),
+            'ingredients': ConjureFieldDefinition('ingredients', List[str])
+        }
+
+    __slots__: List[str] = ['_name', '_ingredients']
+
+    def __init__(self, ingredients: List[str], name: str) -> None:
+        self._name = name
+        self._ingredients = ingredients
+
+    @builtins.property
+    def name(self) -> str:
+        return self._name
+
+    @builtins.property
+    def ingredients(self) -> List[str]:
+        return self._ingredients
+
+
+product_Recipe.__name__ = "Recipe"
+product_Recipe.__qualname__ = "Recipe"
+product_Recipe.__module__ = "package_name.product"
+
+
+class product_RecipeService(Service):
+
+    def get_recipes_by_category(self, category_id: str) -> List["product_Recipe"]:
+        """Get recipes by category
+        """
+        _conjure_encoder = ConjureEncoder()
+
+        _headers: Dict[str, Any] = {
+            'Accept': 'application/json',
+        }
+
+        _params: Dict[str, Any] = {
+        }
+
+        _path_params: Dict[str, str] = {
+            'categoryId': quote(str(_conjure_encoder.default(category_id)), safe=''),
+        }
+
+        _json: Any = None
+
+        _path = '/recipes/category/{categoryId}'
+        _path = _path.format(**_path_params)
+
+        _response: Response = self._request(
+            'GET',
+            self._uri + _path,
+            params=_params,
+            headers=_headers,
+            json=_json)
+
+        _decoder = ConjureDecoder()
+        return _decoder.decode(_response.json(), List[product_Recipe], self._return_none_for_unknown_union_types)
+
+
+product_RecipeService.__name__ = "RecipeService"
+product_RecipeService.__qualname__ = "RecipeService"
+product_RecipeService.__module__ = "package_name.product"
+
+

--- a/conjure-python-core/src/test/resources/errors/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/errors/expected/package_name/_impl.py
@@ -21,17 +21,46 @@ from urllib.parse import (
     quote,
 )
 
-class product_CategoryNotFound(ConjureHTTPError):
-    """Thrown when the requested recipe category doesn't exist
+class product_Dataset(ConjureBeanType):
+
+    @builtins.classmethod
+    def _fields(cls) -> Dict[str, ConjureFieldDefinition]:
+        return {
+            'file_system_id': ConjureFieldDefinition('fileSystemId', str),
+            'rid': ConjureFieldDefinition('rid', str)
+        }
+
+    __slots__: List[str] = ['_file_system_id', '_rid']
+
+    def __init__(self, file_system_id: str, rid: str) -> None:
+        self._file_system_id = file_system_id
+        self._rid = rid
+
+    @builtins.property
+    def file_system_id(self) -> str:
+        return self._file_system_id
+
+    @builtins.property
+    def rid(self) -> str:
+        return self._rid
+
+
+product_Dataset.__name__ = "Dataset"
+product_Dataset.__qualname__ = "Dataset"
+product_Dataset.__module__ = "package_name.product"
+
+
+class product_DatasetNotFound(ConjureHTTPError):
+    """Thrown when the requested dataset does not exist
     """
 
     ERROR_CODE = "NOT_FOUND"
-    ERROR_NAMESPACE = "Recipe"
-    ERROR_NAME = "CategoryNotFound"
+    ERROR_NAMESPACE = "Datasets"
+    ERROR_NAME = "DatasetNotFound"
 
     class SafeArgs(TypedDict):
-        category_id: str
-        available_categories: List[str]
+        dataset_rid: str
+        available_datasets: List[str]
 
     def __init__(self, base_error: ConjureHTTPError) -> None:
         super().__init__(
@@ -41,42 +70,79 @@ class product_CategoryNotFound(ConjureHTTPError):
             error_instance_id=base_error.error_instance_id,
             parameters=base_error.parameters
         )
-        self.safe_args: product_CategoryNotFound.SafeArgs = {
-            'category_id': base_error.parameters['categoryId'],
-            'available_categories': base_error.parameters['availableCategories']
+        self.safe_args: product_DatasetNotFound.SafeArgs = {
+            'dataset_rid': base_error.parameters['datasetRid'],
+            'available_datasets': base_error.parameters['availableDatasets']
         }
 
     @classmethod
     def is_instance(cls, error: ConjureHTTPError) -> bool:
-        """Check if a ConjureHTTPError is this specific error type"""
         return (
             error.error_name == cls.ERROR_NAME and
             error.error_code == cls.ERROR_CODE
         )
 
     @classmethod
-    def from_error(cls, error: ConjureHTTPError) -> 'product_CategoryNotFound':
-        """Convert a generic ConjureHTTPError to this typed error"""
+    def from_error(cls, error: ConjureHTTPError) -> 'product_DatasetNotFound':
         if not cls.is_instance(error):
             raise ValueError(f"Error is not a {cls.ERROR_NAME}")
         return cls(error)
 
 
-product_CategoryNotFound.__name__ = "CategoryNotFound"
-product_CategoryNotFound.__qualname__ = "CategoryNotFound"
-product_CategoryNotFound.__module__ = "package_name.product"
+product_DatasetNotFound.__name__ = "DatasetNotFound"
+product_DatasetNotFound.__qualname__ = "DatasetNotFound"
+product_DatasetNotFound.__module__ = "package_name.product"
 
 
-class product_InvalidIngredient(ConjureHTTPError):
-    """Thrown when an ingredient is invalid for the recipe
+class product_DatasetService(Service):
+
+    def get_datasets_by_file_system(self, file_system_id: str) -> List["product_Dataset"]:
+        """Get datasets by file system
+        """
+        _conjure_encoder = ConjureEncoder()
+
+        _headers: Dict[str, Any] = {
+            'Accept': 'application/json',
+        }
+
+        _params: Dict[str, Any] = {
+        }
+
+        _path_params: Dict[str, str] = {
+            'fileSystemId': quote(str(_conjure_encoder.default(file_system_id)), safe=''),
+        }
+
+        _json: Any = None
+
+        _path = '/datasets/fileSystem/{fileSystemId}'
+        _path = _path.format(**_path_params)
+
+        _response: Response = self._request(
+            'GET',
+            self._uri + _path,
+            params=_params,
+            headers=_headers,
+            json=_json)
+
+        _decoder = ConjureDecoder()
+        return _decoder.decode(_response.json(), List[product_Dataset], self._return_none_for_unknown_union_types)
+
+
+product_DatasetService.__name__ = "DatasetService"
+product_DatasetService.__qualname__ = "DatasetService"
+product_DatasetService.__module__ = "package_name.product"
+
+
+class product_InvalidFileSystemId(ConjureHTTPError):
+    """Thrown when a file system identifier is invalid
     """
 
     ERROR_CODE = "INVALID_ARGUMENT"
-    ERROR_NAMESPACE = "Recipe"
-    ERROR_NAME = "InvalidIngredient"
+    ERROR_NAMESPACE = "Datasets"
+    ERROR_NAME = "InvalidFileSystemId"
 
     class SafeArgs(TypedDict):
-        ingredient_name: str
+        file_system_id: str
 
     class UnsafeArgs(TypedDict):
         user_id: str
@@ -89,99 +155,29 @@ class product_InvalidIngredient(ConjureHTTPError):
             error_instance_id=base_error.error_instance_id,
             parameters=base_error.parameters
         )
-        self.safe_args: product_InvalidIngredient.SafeArgs = {
-            'ingredient_name': base_error.parameters['ingredientName']
+        self.safe_args: product_InvalidFileSystemId.SafeArgs = {
+            'file_system_id': base_error.parameters['fileSystemId']
         }
-        self.unsafe_args: product_InvalidIngredient.UnsafeArgs = {
+        self.unsafe_args: product_InvalidFileSystemId.UnsafeArgs = {
             'user_id': base_error.parameters['userId']
         }
 
     @classmethod
     def is_instance(cls, error: ConjureHTTPError) -> bool:
-        """Check if a ConjureHTTPError is this specific error type"""
         return (
             error.error_name == cls.ERROR_NAME and
             error.error_code == cls.ERROR_CODE
         )
 
     @classmethod
-    def from_error(cls, error: ConjureHTTPError) -> 'product_InvalidIngredient':
-        """Convert a generic ConjureHTTPError to this typed error"""
+    def from_error(cls, error: ConjureHTTPError) -> 'product_InvalidFileSystemId':
         if not cls.is_instance(error):
             raise ValueError(f"Error is not a {cls.ERROR_NAME}")
         return cls(error)
 
 
-product_InvalidIngredient.__name__ = "InvalidIngredient"
-product_InvalidIngredient.__qualname__ = "InvalidIngredient"
-product_InvalidIngredient.__module__ = "package_name.product"
-
-
-class product_Recipe(ConjureBeanType):
-
-    @builtins.classmethod
-    def _fields(cls) -> Dict[str, ConjureFieldDefinition]:
-        return {
-            'name': ConjureFieldDefinition('name', str),
-            'ingredients': ConjureFieldDefinition('ingredients', List[str])
-        }
-
-    __slots__: List[str] = ['_name', '_ingredients']
-
-    def __init__(self, ingredients: List[str], name: str) -> None:
-        self._name = name
-        self._ingredients = ingredients
-
-    @builtins.property
-    def name(self) -> str:
-        return self._name
-
-    @builtins.property
-    def ingredients(self) -> List[str]:
-        return self._ingredients
-
-
-product_Recipe.__name__ = "Recipe"
-product_Recipe.__qualname__ = "Recipe"
-product_Recipe.__module__ = "package_name.product"
-
-
-class product_RecipeService(Service):
-
-    def get_recipes_by_category(self, category_id: str) -> List["product_Recipe"]:
-        """Get recipes by category
-        """
-        _conjure_encoder = ConjureEncoder()
-
-        _headers: Dict[str, Any] = {
-            'Accept': 'application/json',
-        }
-
-        _params: Dict[str, Any] = {
-        }
-
-        _path_params: Dict[str, str] = {
-            'categoryId': quote(str(_conjure_encoder.default(category_id)), safe=''),
-        }
-
-        _json: Any = None
-
-        _path = '/recipes/category/{categoryId}'
-        _path = _path.format(**_path_params)
-
-        _response: Response = self._request(
-            'GET',
-            self._uri + _path,
-            params=_params,
-            headers=_headers,
-            json=_json)
-
-        _decoder = ConjureDecoder()
-        return _decoder.decode(_response.json(), List[product_Recipe], self._return_none_for_unknown_union_types)
-
-
-product_RecipeService.__name__ = "RecipeService"
-product_RecipeService.__qualname__ = "RecipeService"
-product_RecipeService.__module__ = "package_name.product"
+product_InvalidFileSystemId.__name__ = "InvalidFileSystemId"
+product_InvalidFileSystemId.__qualname__ = "InvalidFileSystemId"
+product_InvalidFileSystemId.__module__ = "package_name.product"
 
 

--- a/conjure-python-core/src/test/resources/errors/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/errors/expected/package_name/_impl.py
@@ -8,6 +8,7 @@ from conjure_python_client import (
     OptionalTypeWrapper,
     Service,
 )
+import json
 from requests.adapters import (
     Response,
 )
@@ -21,49 +22,6 @@ from urllib.parse import (
     quote,
 )
 import uuid
-
-class product_ContextWindowExceeded(Exception):
-    """The supplied input exceeded the model's maximum context window.
-    """
-
-    ERROR_CODE = "INVALID_ARGUMENT"
-    ERROR_NAMESPACE = "Datasets"
-    ERROR_NAME = "Datasets:ContextWindowExceeded"
-
-    def __init__(self, input_token_count: int, max_tokens: int, error_instance_id: Optional[str] = None) -> None:
-        self.input_token_count = input_token_count
-        self.max_tokens = max_tokens
-        self.error_instance_id = error_instance_id if error_instance_id is not None else str(uuid.uuid4())
-        super().__init__(self.ERROR_NAME)
-
-    def encode(self) -> Dict[str, Any]:
-        return {
-            'errorCode': self.ERROR_CODE,
-            'errorName': self.ERROR_NAME,
-            'errorInstanceId': self.error_instance_id,
-            'parameters': {
-                'inputTokenCount': ConjureEncoder.do_encode(self.input_token_count),
-                'maxTokens': ConjureEncoder.do_encode(self.max_tokens)
-            }
-        }
-
-    @builtins.classmethod
-    def decode(cls, error: Dict[str, Any]) -> 'product_ContextWindowExceeded':
-        if error.get('errorName') != cls.ERROR_NAME:
-            raise ValueError(f"Error '{error.get('errorName')}' is not a {cls.ERROR_NAME}")
-        decoder = ConjureDecoder()
-        parameters = error.get('parameters', {})
-        return cls(
-            input_token_count=decoder.decode(parameters.get('inputTokenCount'), int),
-            max_tokens=decoder.decode(parameters.get('maxTokens'), int),
-            error_instance_id=error.get('errorInstanceId')
-        )
-
-
-product_ContextWindowExceeded.__name__ = "ContextWindowExceeded"
-product_ContextWindowExceeded.__qualname__ = "ContextWindowExceeded"
-product_ContextWindowExceeded.__module__ = "package_name.product"
-
 
 class product_Dataset(ConjureBeanType):
 
@@ -103,10 +61,18 @@ class product_DatasetNotFound(Exception):
     ERROR_NAME = "Datasets:DatasetNotFound"
 
     def __init__(self, dataset_rid: str, available_datasets: List[str], error_instance_id: Optional[str] = None) -> None:
-        self.dataset_rid = dataset_rid
-        self.available_datasets = available_datasets
+        self._dataset_rid = dataset_rid
+        self._available_datasets = available_datasets
         self.error_instance_id = error_instance_id if error_instance_id is not None else str(uuid.uuid4())
         super().__init__(self.ERROR_NAME)
+
+    @builtins.property
+    def dataset_rid(self) -> str:
+        return self._dataset_rid
+
+    @builtins.property
+    def available_datasets(self) -> List[str]:
+        return self._available_datasets
 
     def encode(self) -> Dict[str, Any]:
         return {
@@ -119,6 +85,15 @@ class product_DatasetNotFound(Exception):
             }
         }
 
+    @builtins.staticmethod
+    def _decode_parameter(decoder: ConjureDecoder, value: Any, conjure_type: Any) -> Any:
+        if isinstance(value, str) and conjure_type is not str:
+            try:
+                value = json.loads(value)
+            except (ValueError, TypeError):
+                pass
+        return decoder.decode(value, conjure_type)
+
     @builtins.classmethod
     def decode(cls, error: Dict[str, Any]) -> 'product_DatasetNotFound':
         if error.get('errorName') != cls.ERROR_NAME:
@@ -126,8 +101,8 @@ class product_DatasetNotFound(Exception):
         decoder = ConjureDecoder()
         parameters = error.get('parameters', {})
         return cls(
-            dataset_rid=decoder.decode(parameters.get('datasetRid'), str),
-            available_datasets=decoder.decode(parameters.get('availableDatasets'), List[str]),
+            dataset_rid=cls._decode_parameter(decoder, parameters.get('datasetRid'), str),
+            available_datasets=cls._decode_parameter(decoder, parameters.get('availableDatasets'), List[str]),
             error_instance_id=error.get('errorInstanceId')
         )
 
@@ -185,11 +160,23 @@ class product_InvalidFileSystemId(Exception):
     ERROR_NAME = "Datasets:InvalidFileSystemId"
 
     def __init__(self, file_system_id: str, reason: Optional[str], user_id: str, error_instance_id: Optional[str] = None) -> None:
-        self.file_system_id = file_system_id
-        self.reason = reason
-        self.user_id = user_id
+        self._file_system_id = file_system_id
+        self._reason = reason
+        self._user_id = user_id
         self.error_instance_id = error_instance_id if error_instance_id is not None else str(uuid.uuid4())
         super().__init__(self.ERROR_NAME)
+
+    @builtins.property
+    def file_system_id(self) -> str:
+        return self._file_system_id
+
+    @builtins.property
+    def reason(self) -> Optional[str]:
+        return self._reason
+
+    @builtins.property
+    def user_id(self) -> str:
+        return self._user_id
 
     def encode(self) -> Dict[str, Any]:
         return {
@@ -203,6 +190,15 @@ class product_InvalidFileSystemId(Exception):
             }
         }
 
+    @builtins.staticmethod
+    def _decode_parameter(decoder: ConjureDecoder, value: Any, conjure_type: Any) -> Any:
+        if isinstance(value, str) and conjure_type is not str:
+            try:
+                value = json.loads(value)
+            except (ValueError, TypeError):
+                pass
+        return decoder.decode(value, conjure_type)
+
     @builtins.classmethod
     def decode(cls, error: Dict[str, Any]) -> 'product_InvalidFileSystemId':
         if error.get('errorName') != cls.ERROR_NAME:
@@ -210,9 +206,9 @@ class product_InvalidFileSystemId(Exception):
         decoder = ConjureDecoder()
         parameters = error.get('parameters', {})
         return cls(
-            file_system_id=decoder.decode(parameters.get('fileSystemId'), str),
-            reason=decoder.decode(parameters.get('reason'), OptionalTypeWrapper[str]),
-            user_id=decoder.decode(parameters.get('userId'), str),
+            file_system_id=cls._decode_parameter(decoder, parameters.get('fileSystemId'), str),
+            reason=cls._decode_parameter(decoder, parameters.get('reason'), OptionalTypeWrapper[str]),
+            user_id=cls._decode_parameter(decoder, parameters.get('userId'), str),
             error_instance_id=error.get('errorInstanceId')
         )
 

--- a/conjure-python-core/src/test/resources/errors/expected/package_name/_impl.py
+++ b/conjure-python-core/src/test/resources/errors/expected/package_name/_impl.py
@@ -8,7 +8,6 @@ from conjure_python_client import (
     OptionalTypeWrapper,
     Service,
 )
-import json
 from requests.adapters import (
     Response,
 )
@@ -85,15 +84,6 @@ class product_DatasetNotFound(Exception):
             }
         }
 
-    @builtins.staticmethod
-    def _decode_parameter(decoder: ConjureDecoder, value: Any, conjure_type: Any) -> Any:
-        if isinstance(value, str) and conjure_type is not str:
-            try:
-                value = json.loads(value)
-            except (ValueError, TypeError):
-                pass
-        return decoder.decode(value, conjure_type)
-
     @builtins.classmethod
     def decode(cls, error: Dict[str, Any]) -> 'product_DatasetNotFound':
         if error.get('errorName') != cls.ERROR_NAME:
@@ -101,8 +91,8 @@ class product_DatasetNotFound(Exception):
         decoder = ConjureDecoder()
         parameters = error.get('parameters', {})
         return cls(
-            dataset_rid=cls._decode_parameter(decoder, parameters.get('datasetRid'), str),
-            available_datasets=cls._decode_parameter(decoder, parameters.get('availableDatasets'), List[str]),
+            dataset_rid=decoder.decode(parameters.get('datasetRid'), str),
+            available_datasets=decoder.decode(parameters.get('availableDatasets'), List[str]),
             error_instance_id=error.get('errorInstanceId')
         )
 
@@ -190,15 +180,6 @@ class product_InvalidFileSystemId(Exception):
             }
         }
 
-    @builtins.staticmethod
-    def _decode_parameter(decoder: ConjureDecoder, value: Any, conjure_type: Any) -> Any:
-        if isinstance(value, str) and conjure_type is not str:
-            try:
-                value = json.loads(value)
-            except (ValueError, TypeError):
-                pass
-        return decoder.decode(value, conjure_type)
-
     @builtins.classmethod
     def decode(cls, error: Dict[str, Any]) -> 'product_InvalidFileSystemId':
         if error.get('errorName') != cls.ERROR_NAME:
@@ -206,9 +187,9 @@ class product_InvalidFileSystemId(Exception):
         decoder = ConjureDecoder()
         parameters = error.get('parameters', {})
         return cls(
-            file_system_id=cls._decode_parameter(decoder, parameters.get('fileSystemId'), str),
-            reason=cls._decode_parameter(decoder, parameters.get('reason'), OptionalTypeWrapper[str]),
-            user_id=cls._decode_parameter(decoder, parameters.get('userId'), str),
+            file_system_id=decoder.decode(parameters.get('fileSystemId'), str),
+            reason=decoder.decode(parameters.get('reason'), OptionalTypeWrapper[str]),
+            user_id=decoder.decode(parameters.get('userId'), str),
             error_instance_id=error.get('errorInstanceId')
         )
 

--- a/conjure-python-core/src/test/resources/errors/expected/package_name/product/__init__.py
+++ b/conjure-python-core/src/test/resources/errors/expected/package_name/product/__init__.py
@@ -1,0 +1,15 @@
+# coding=utf-8
+from .._impl import (
+    product_CategoryNotFound as CategoryNotFound,
+    product_InvalidIngredient as InvalidIngredient,
+    product_Recipe as Recipe,
+    product_RecipeService as RecipeService,
+)
+
+__all__ = [
+    'Recipe',
+    'RecipeService',
+    'CategoryNotFound',
+    'InvalidIngredient',
+]
+

--- a/conjure-python-core/src/test/resources/errors/expected/package_name/product/__init__.py
+++ b/conjure-python-core/src/test/resources/errors/expected/package_name/product/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from .._impl import (
+    product_ContextWindowExceeded as ContextWindowExceeded,
     product_Dataset as Dataset,
     product_DatasetNotFound as DatasetNotFound,
     product_DatasetService as DatasetService,
@@ -9,6 +10,7 @@ from .._impl import (
 __all__ = [
     'Dataset',
     'DatasetService',
+    'ContextWindowExceeded',
     'DatasetNotFound',
     'InvalidFileSystemId',
 ]

--- a/conjure-python-core/src/test/resources/errors/expected/package_name/product/__init__.py
+++ b/conjure-python-core/src/test/resources/errors/expected/package_name/product/__init__.py
@@ -1,15 +1,15 @@
 # coding=utf-8
 from .._impl import (
-    product_CategoryNotFound as CategoryNotFound,
-    product_InvalidIngredient as InvalidIngredient,
-    product_Recipe as Recipe,
-    product_RecipeService as RecipeService,
+    product_Dataset as Dataset,
+    product_DatasetNotFound as DatasetNotFound,
+    product_DatasetService as DatasetService,
+    product_InvalidFileSystemId as InvalidFileSystemId,
 )
 
 __all__ = [
-    'Recipe',
-    'RecipeService',
-    'CategoryNotFound',
-    'InvalidIngredient',
+    'Dataset',
+    'DatasetService',
+    'DatasetNotFound',
+    'InvalidFileSystemId',
 ]
 

--- a/conjure-python-core/src/test/resources/errors/expected/package_name/product/__init__.py
+++ b/conjure-python-core/src/test/resources/errors/expected/package_name/product/__init__.py
@@ -1,6 +1,5 @@
 # coding=utf-8
 from .._impl import (
-    product_ContextWindowExceeded as ContextWindowExceeded,
     product_Dataset as Dataset,
     product_DatasetNotFound as DatasetNotFound,
     product_DatasetService as DatasetService,
@@ -10,7 +9,6 @@ from .._impl import (
 __all__ = [
     'Dataset',
     'DatasetService',
-    'ContextWindowExceeded',
     'DatasetNotFound',
     'InvalidFileSystemId',
 ]

--- a/conjure-python-core/src/test/resources/errors/expected/package_name/py.typed
+++ b/conjure-python-core/src/test/resources/errors/expected/package_name/py.typed
@@ -1,0 +1,1 @@
+# coding=utf-8

--- a/conjure-python-core/src/test/resources/errors/expected/setup.py
+++ b/conjure-python-core/src/test/resources/errors/expected/setup.py
@@ -1,0 +1,18 @@
+# coding=utf-8
+from setuptools import (
+    find_packages,
+    setup,
+)
+
+setup(
+    name='package-name',
+    version='0.0.0',
+    python_requires='>=3.8',
+    description='project description',
+    package_data={"": ["py.typed"]},
+    packages=find_packages(),
+    install_requires=[
+        'requests',
+        'conjure-python-client>=2.8.0,<4',
+    ],
+)

--- a/conjure-python-verifier/build.gradle
+++ b/conjure-python-verifier/build.gradle
@@ -59,7 +59,8 @@ task generateIntegrationTests(type: JavaExec, dependsOn: [compileIr, ':conjure-p
             'build/conjure-ir/conjure-python-verifier.conjure.json',
             'python/tests',
             '--packageName', 'generated_integration',
-            '--packageVersion', '0.0.0'
+            '--packageVersion', '0.0.0',
+            '--generateErrorTypes'
 
     inputs.files configurations.verificationApi
     doLast { delete "python/tests/setup.py" }

--- a/conjure-python-verifier/python/tests/client/test_errors.py
+++ b/conjure-python-verifier/python/tests/client/test_errors.py
@@ -19,7 +19,7 @@ from generated_integration.product import ContextWindowExceeded, InvalidFileSyst
 def test_encode_produces_serializable_error():
     err = ContextWindowExceeded(input_token_count=5, max_tokens=4096)
     encoded = err.encode()
-    assert encoded["errorName"] == "MioMl:ContextWindowExceeded"
+    assert encoded["errorName"] == "Datasets:ContextWindowExceeded"
     assert encoded["errorCode"] == "INVALID_ARGUMENT"
     assert encoded["parameters"] == {"inputTokenCount": 5, "maxTokens": 4096}
     assert len(encoded["errorInstanceId"]) == 36

--- a/conjure-python-verifier/python/tests/client/test_errors.py
+++ b/conjure-python-verifier/python/tests/client/test_errors.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import pytest
-from conjure_python_client import ConjureDecoder
 from generated_integration.product import DatasetNotFound, InvalidFileSystemId
 
 
@@ -39,13 +38,6 @@ def test_optional_argument_round_trips_absent_and_present():
     assert InvalidFileSystemId.decode(absent.encode()).reason is None
     present = InvalidFileSystemId(file_system_id="fs1", reason="bad", user_id="u1")
     assert InvalidFileSystemId.decode(present.encode()).reason == "bad"
-
-
-def test_decode_recovers_legacy_stringified_scalar_params():
-    decoder = ConjureDecoder()
-    assert DatasetNotFound._decode_parameter(decoder, "5", int) == 5
-    assert DatasetNotFound._decode_parameter(decoder, "true", bool) is True
-    assert DatasetNotFound._decode_parameter(decoder, "ri.dataset.1", str) == "ri.dataset.1"
 
 
 def test_decode_rejects_mismatched_error_name():

--- a/conjure-python-verifier/python/tests/client/test_errors.py
+++ b/conjure-python-verifier/python/tests/client/test_errors.py
@@ -1,0 +1,45 @@
+# (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from generated_integration.product import ContextWindowExceeded, InvalidFileSystemId
+
+
+def test_encode_produces_serializable_error():
+    err = ContextWindowExceeded(input_token_count=5, max_tokens=4096)
+    encoded = err.encode()
+    assert encoded["errorName"] == "MioMl:ContextWindowExceeded"
+    assert encoded["errorCode"] == "INVALID_ARGUMENT"
+    assert encoded["parameters"] == {"inputTokenCount": 5, "maxTokens": 4096}
+    assert len(encoded["errorInstanceId"]) == 36
+
+
+def test_encode_decode_round_trip():
+    err = ContextWindowExceeded(input_token_count=5, max_tokens=4096)
+    decoded = ContextWindowExceeded.decode(err.encode())
+    assert decoded.input_token_count == 5
+    assert decoded.max_tokens == 4096
+    assert decoded.error_instance_id == err.error_instance_id
+
+
+def test_optional_argument_round_trips_absent_and_present():
+    absent = InvalidFileSystemId(file_system_id="fs1", reason=None, user_id="u1")
+    assert InvalidFileSystemId.decode(absent.encode()).reason is None
+    present = InvalidFileSystemId(file_system_id="fs1", reason="bad", user_id="u1")
+    assert InvalidFileSystemId.decode(present.encode()).reason == "bad"
+
+
+def test_decode_rejects_mismatched_error_name():
+    with pytest.raises(ValueError):
+        ContextWindowExceeded.decode({"errorName": "MioMl:SomethingElse", "parameters": {}})

--- a/conjure-python-verifier/python/tests/client/test_errors.py
+++ b/conjure-python-verifier/python/tests/client/test_errors.py
@@ -13,23 +13,24 @@
 # limitations under the License.
 
 import pytest
-from generated_integration.product import ContextWindowExceeded, InvalidFileSystemId
+from conjure_python_client import ConjureDecoder
+from generated_integration.product import DatasetNotFound, InvalidFileSystemId
 
 
 def test_encode_produces_serializable_error():
-    err = ContextWindowExceeded(input_token_count=5, max_tokens=4096)
+    err = DatasetNotFound(dataset_rid="ri.dataset.1", available_datasets=["ri.dataset.2"])
     encoded = err.encode()
-    assert encoded["errorName"] == "Datasets:ContextWindowExceeded"
-    assert encoded["errorCode"] == "INVALID_ARGUMENT"
-    assert encoded["parameters"] == {"inputTokenCount": 5, "maxTokens": 4096}
+    assert encoded["errorName"] == "Datasets:DatasetNotFound"
+    assert encoded["errorCode"] == "NOT_FOUND"
+    assert encoded["parameters"] == {"datasetRid": "ri.dataset.1", "availableDatasets": ["ri.dataset.2"]}
     assert len(encoded["errorInstanceId"]) == 36
 
 
 def test_encode_decode_round_trip():
-    err = ContextWindowExceeded(input_token_count=5, max_tokens=4096)
-    decoded = ContextWindowExceeded.decode(err.encode())
-    assert decoded.input_token_count == 5
-    assert decoded.max_tokens == 4096
+    err = DatasetNotFound(dataset_rid="ri.dataset.1", available_datasets=["ri.dataset.2"])
+    decoded = DatasetNotFound.decode(err.encode())
+    assert decoded.dataset_rid == "ri.dataset.1"
+    assert decoded.available_datasets == ["ri.dataset.2"]
     assert decoded.error_instance_id == err.error_instance_id
 
 
@@ -40,6 +41,13 @@ def test_optional_argument_round_trips_absent_and_present():
     assert InvalidFileSystemId.decode(present.encode()).reason == "bad"
 
 
+def test_decode_recovers_legacy_stringified_scalar_params():
+    decoder = ConjureDecoder()
+    assert DatasetNotFound._decode_parameter(decoder, "5", int) == 5
+    assert DatasetNotFound._decode_parameter(decoder, "true", bool) is True
+    assert DatasetNotFound._decode_parameter(decoder, "ri.dataset.1", str) == "ri.dataset.1"
+
+
 def test_decode_rejects_mismatched_error_name():
     with pytest.raises(ValueError):
-        ContextWindowExceeded.decode({"errorName": "MioMl:SomethingElse", "parameters": {}})
+        DatasetNotFound.decode({"errorName": "Datasets:SomethingElse", "parameters": {}})

--- a/conjure-python-verifier/src/main/conjure/example-errors.conjure.yml
+++ b/conjure-python-verifier/src/main/conjure/example-errors.conjure.yml
@@ -3,7 +3,7 @@ types:
     default-package: com.palantir.product
     errors:
       ContextWindowExceeded:
-        namespace: MioMl
+        namespace: Datasets
         code: INVALID_ARGUMENT
         safe-args:
           inputTokenCount: integer

--- a/conjure-python-verifier/src/main/conjure/example-errors.conjure.yml
+++ b/conjure-python-verifier/src/main/conjure/example-errors.conjure.yml
@@ -1,0 +1,21 @@
+types:
+  definitions:
+    default-package: com.palantir.product
+    errors:
+      ContextWindowExceeded:
+        namespace: MioMl
+        code: INVALID_ARGUMENT
+        safe-args:
+          inputTokenCount: integer
+          maxTokens: integer
+        docs: The supplied input exceeded the model's maximum context window.
+
+      InvalidFileSystemId:
+        namespace: Datasets
+        code: INVALID_ARGUMENT
+        safe-args:
+          fileSystemId: string
+          reason: optional<string>
+        unsafe-args:
+          userId: string
+        docs: Thrown when a file system identifier is invalid

--- a/conjure-python-verifier/src/main/conjure/example-errors.conjure.yml
+++ b/conjure-python-verifier/src/main/conjure/example-errors.conjure.yml
@@ -2,13 +2,13 @@ types:
   definitions:
     default-package: com.palantir.product
     errors:
-      ContextWindowExceeded:
+      DatasetNotFound:
         namespace: Datasets
-        code: INVALID_ARGUMENT
+        code: NOT_FOUND
         safe-args:
-          inputTokenCount: integer
-          maxTokens: integer
-        docs: The supplied input exceeded the model's maximum context window.
+          datasetRid: string
+          availableDatasets: list<string>
+        docs: Thrown when the requested dataset does not exist
 
       InvalidFileSystemId:
         namespace: Datasets

--- a/conjure-python/src/main/java/com/palantir/conjure/python/cli/CliConfiguration.java
+++ b/conjure-python/src/main/java/com/palantir/conjure/python/cli/CliConfiguration.java
@@ -51,6 +51,12 @@ public abstract class CliConfiguration {
         return false;
     }
 
+    @Value.Default
+    @SuppressWarnings("DesignForExtension")
+    boolean generateErrorTypes() {
+        return false;
+    }
+
     @Value.Check
     final void check() {
         Preconditions.checkArgument(input().isFile(), "Target must exist and be a file");

--- a/conjure-python/src/main/java/com/palantir/conjure/python/cli/ConjurePythonCli.java
+++ b/conjure-python/src/main/java/com/palantir/conjure/python/cli/ConjurePythonCli.java
@@ -89,6 +89,12 @@ public final class ConjurePythonCli implements Runnable {
                 description = "Generate a `conda_recipe/meta.yaml`")
         private boolean writeCondaRecipe;
 
+        @CommandLine.Option(
+                names = "--generateErrorTypes",
+                defaultValue = "false",
+                description = "Generate typed error classes from Conjure error definitions")
+        private boolean generateErrorTypes;
+
         @CommandLine.Unmatched
         @SuppressWarnings("StrictUnusedVariable")
         private List<String> unmatchedOptions;
@@ -118,6 +124,7 @@ public final class ConjurePythonCli implements Runnable {
                     .packageUrl(Optional.ofNullable(packageUrl))
                     .generateRawSource(rawSource)
                     .shouldWriteCondaRecipe(writeCondaRecipe)
+                    .generateErrorTypes(generateErrorTypes)
                     .build();
         }
 
@@ -134,6 +141,7 @@ public final class ConjurePythonCli implements Runnable {
                     .packageUrl(cliConfig.packageUrl())
                     .shouldWriteCondaRecipe(cliConfig.shouldWriteCondaRecipe())
                     .generateRawSource(cliConfig.generateRawSource())
+                    .generateErrorTypes(cliConfig.generateErrorTypes())
                     .build();
         }
     }


### PR DESCRIPTION
branch off: https://github.com/palantir/conjure-python/pull/1157

For issue: https://github.com/palantir/conjure-python/issues/910

## After this PR

The resulting error looks like:

Conjure:
```yaml
types:
  definitions:
    default-package: com.palantir.product
    errors:
      DatasetNotFound:
        namespace: Datasets
        code: NOT_FOUND
        docs: Thrown when the requested dataset does not exist
        safe-args:
          datasetRid:
            type: string
            docs: The resource identifier of the dataset that was requested.
          availableDatasets: list<string>
```

Python:
```python
class product_DatasetNotFound(Exception):
    """Thrown when the requested dataset does not exist
    """

    ERROR_CODE = "NOT_FOUND"
    ERROR_NAMESPACE = "Datasets"
    ERROR_NAME = "Datasets:DatasetNotFound"

    def __init__(self, dataset_rid: str, available_datasets: List[str], error_instance_id: Optional[str] = None) -> None:
        self._dataset_rid = dataset_rid
        self._available_datasets = available_datasets
        self.error_instance_id = error_instance_id if error_instance_id is not None else str(uuid.uuid4())
        super().__init__(self.ERROR_NAME)

    @builtins.property
    def dataset_rid(self) -> str:
        return self._dataset_rid

    @builtins.property
    def available_datasets(self) -> List[str]:
        return self._available_datasets

    def encode(self) -> Dict[str, Any]:
        return {
            'errorCode': self.ERROR_CODE,
            'errorName': self.ERROR_NAME,
            'errorInstanceId': self.error_instance_id,
            'parameters': {
                'datasetRid': ConjureEncoder.do_encode(self.dataset_rid),
                'availableDatasets': ConjureEncoder.do_encode(self.available_datasets)
            }
        }

    @builtins.classmethod
    def decode(cls, error: Dict[str, Any]) -> 'product_DatasetNotFound':
        if error.get('errorName') != cls.ERROR_NAME:
            raise ValueError(f"Error '{error.get('errorName')}' is not a {cls.ERROR_NAME}")
        decoder = ConjureDecoder()
        parameters = error.get('parameters', {})
        return cls(
            dataset_rid=decoder.decode(parameters.get('datasetRid'), str),
            available_datasets=decoder.decode(parameters.get('availableDatasets'), List[str]),
            error_instance_id=error.get('errorInstanceId')
        )


product_DatasetNotFound.__name__ = "DatasetNotFound"
product_DatasetNotFound.__qualname__ = "DatasetNotFound"
product_DatasetNotFound.__module__ = "package_name.product"
```

Server side — create / serialize:
```python
from my_package.product import DatasetNotFound

# raise it like any other exception
raise DatasetNotFound(
    dataset_rid="ri.foundry.main.dataset.123",
    available_datasets=["ri.foundry.main.dataset.456"],
)

# or serialize to the Conjure SerializableError envelope
payload = DatasetNotFound(
    dataset_rid="ri.foundry.main.dataset.123",
    available_datasets=["ri.foundry.main.dataset.456"],
).encode()
# {
#   'errorCode': 'NOT_FOUND',
#   'errorName': 'Datasets:DatasetNotFound',
#   'errorInstanceId': '<uuid>',
#   'parameters': {
#       'datasetRid': 'ri.foundry.main.dataset.123',
#       'availableDatasets': ['ri.foundry.main.dataset.456'],
#   },
# }
```

Client side — deserialize:
```python
from my_package.product import DatasetNotFound

# `payload` is a Conjure SerializableError (e.g. an error response body)
error = DatasetNotFound.decode(payload)
error.dataset_rid         # 'ri.foundry.main.dataset.123'
error.available_datasets  # ['ri.foundry.main.dataset.456']
error.error_instance_id   # '<uuid>'

# decode() raises ValueError if the payload's errorName doesn't match
```

Also placed a follow-up item for using the enum for `ErrorCode` after https://github.com/palantir/conjure-python-client/pull/171.
